### PR TITLE
Landlord tenants

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1,0 +1,2394 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@iconify-json/ic':
+        specifier: ^1.2.4
+        version: 1.2.4
+      axios:
+        specifier: ^1.15.2
+        version: 1.16.0
+      framer-motion:
+        specifier: ^12.38.0
+        version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      leaflet:
+        specifier: ^1.9.4
+        version: 1.9.4
+      react:
+        specifier: ^19.2.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.5(react@19.2.5)
+      react-hook-form:
+        specifier: ^7.73.1
+        version: 7.75.0(react@19.2.5)
+      react-leaflet:
+        specifier: ^5.0.0
+        version: 5.0.0(leaflet@1.9.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-router-dom:
+        specifier: ^7.14.0
+        version: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      yet-another-react-lightbox:
+        specifier: ^3.31.0
+        version: 3.31.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.2
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.5)
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.12
+        version: 2.4.13
+      '@iconify/react':
+        specifier: ^6.0.2
+        version: 6.0.2(react@19.2.5)
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@types/leaflet':
+        specifier: ^1.9.21
+        version: 1.9.21
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.12.2
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.1
+        version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0))
+      shared:
+        specifier: '*'
+        version: 0.2.0
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite-plugin-svgr:
+        specifier: ^5.2.0
+        version: 5.2.0(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0))
+
+packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.4.13':
+    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.13':
+    resolution: {integrity: sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@iconify-json/ic@1.2.4':
+    resolution: {integrity: sha512-pzPMmrZrBQuwT7nmtrYdkttun8KalRGgZPIL1Ny9KpF2zjRGIUPN+npTfuD3lrgO/OnSwAoJWuekQwBpt/Cqrw==}
+
+  '@iconify/react@6.0.2':
+    resolution: {integrity: sha512-SMmC2sactfpJD427WJEDN6PMyznTFMhByK9yLW0gOTtnjzzbsi/Ke/XqsumsavFPwNiXs8jSiYeZTmLCLwO+Fg==}
+    peerDependencies:
+      react: '>=16'
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@react-leaflet/core@3.0.0':
+    resolution: {integrity: sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==}
+    peerDependencies:
+      leaflet: ^1.9.0
+      react: ^19.0.0
+      react-dom: ^19.0.0
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
+    resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0':
+    resolution: {integrity: sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0':
+    resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0':
+    resolution: {integrity: sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0':
+    resolution: {integrity: sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0':
+    resolution: {integrity: sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0':
+    resolution: {integrity: sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-transform-svg-component@8.0.0':
+    resolution: {integrity: sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-preset@8.1.0':
+    resolution: {integrity: sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/core@8.1.0':
+    resolution: {integrity: sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==}
+    engines: {node: '>=14'}
+
+  '@svgr/hast-util-to-babel-ast@8.0.0':
+    resolution: {integrity: sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==}
+    engines: {node: '>=14'}
+
+  '@svgr/plugin-jsx@8.1.0':
+    resolution: {integrity: sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@svgr/core': '*'
+
+  '@tailwindcss/node@4.2.4':
+    resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.4':
+    resolution: {integrity: sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+    resolution: {integrity: sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.4':
+    resolution: {integrity: sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+    resolution: {integrity: sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+    resolution: {integrity: sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+    resolution: {integrity: sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+    resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+    resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+    resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+    resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+    resolution: {integrity: sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+    resolution: {integrity: sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.4':
+    resolution: {integrity: sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.4':
+    resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/leaflet@1.9.21':
+    resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
+
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+
+  baseline-browser-mapping@2.10.20:
+    resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  bintrees@0.0.10:
+    resolution: {integrity: sha512-BkR37mfNUjTN36dENR1V6BlW8rqzpJnqCBhe2ZtWXJ1UgTVPHIlWSfYX7Ap/FlAgl7XWRr3mG4eR2LFnezBG1g==}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bson@0.1.8:
+    resolution: {integrity: sha512-Zen/6PF3Mox895jY2kVBC8m/zbApUgUoGwQ7p+UqdcByls5aYNgE4CrpXgycsPcMio+wto6nRvhJlJuZr5hxBw==}
+    engines: {node: '>=0.6.19'}
+    deprecated: Fixed a critical issue with BSON serialization documented in CVE-2019-2391, see https://bit.ly/2KcpXdo for more details
+
+  bson@0.1.9:
+    resolution: {integrity: sha512-HlvXnohuuxlb/AzILVZFgGBO7658NPddPn1Q8PRC6ANHoPZKJotU0WG9+PoMjO7ZFM/e+jKbqOstXJLyIhSOgA==}
+    engines: {node: '>=0.6.19'}
+    deprecated: Fixed a critical issue with BSON serialization documented in CVE-2019-2391, see https://bit.ly/2KcpXdo for more details
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  caniuse-lite@1.0.30001788:
+    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  cosmiconfig@8.3.6:
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  electron-to-chromium@1.5.340:
+    resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
+
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+    engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  framer-motion@12.38.0:
+    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  leaflet@1.9.4:
+    resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mongodb@1.2.14:
+    resolution: {integrity: sha512-6e+wAdsDC8LXAiDd8hyvs3PelKsJC/zIuNehU3FeI4JidhoYW2CG3jGTshg9MI8UKPrcyB8sqY0blpRFPYPLSg==}
+    engines: {node: '>=0.6.19'}
+    deprecated: Please upgrade to 2.2.19 or higher
+
+  motion-dom@12.38.0:
+    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+
+  motion-utils@12.36.0:
+    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
+  node-releases@2.0.37:
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  node-uuid@1.3.3:
+    resolution: {integrity: sha512-xKQtL5imfvX6PvUmgJyU/XaNT/l8tKvs+sJ6KLOmIzk/H8+sm7uE80QlPmmu3l1uirvRL3kZqtJPWoQBWT9gQw==}
+    deprecated: Use uuid module instead
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-hook-form@7.75.0:
+    resolution: {integrity: sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-leaflet@5.0.0:
+    resolution: {integrity: sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==}
+    peerDependencies:
+      leaflet: ^1.9.0
+      react: ^19.0.0
+      react-dom: ^19.0.0
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react-router-dom@7.14.1:
+    resolution: {integrity: sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.14.1:
+    resolution: {integrity: sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  shared@0.2.0:
+    resolution: {integrity: sha512-nRBVf7KHFkU4vmiKAhTaJUm8miFMcU6b5I98U71Kk6uu1RIBeRwWivnMXEQOQxTxObPhOSIQSBhuIT+O/urG3A==}
+    bundledDependencies:
+      - rsvp
+
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  svg-parser@2.0.4:
+    resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
+
+  tailwindcss@4.2.4:
+    resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
+
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
+    engines: {node: '>=6'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  underscore@1.4.4:
+    resolution: {integrity: sha512-ZqGrAgaqqZM7LGRzNjLnw5elevWb5M8LEoDMadxIW3OWbcv72wMMgKdwOKpd5Fqxe8choLD8HN3iSj3TUh/giQ==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite-plugin-svgr@5.2.0:
+    resolution: {integrity: sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ==}
+    peerDependencies:
+      vite: '>=3.0.0'
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yet-another-react-lightbox@3.31.0:
+    resolution: {integrity: sha512-qcj8Vz5Gpbl2/XCXW/4vAdLGganPHEL1D5VgHxBQWbPF8ZeomH1DSN2ci++kv/1hMlccpUkg/nNx2CrMf9cLAg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@types/react': ^16 || ^17 || ^18 || ^19
+      '@types/react-dom': ^16 || ^17 || ^18 || ^19
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: ^16.8.0 || ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  zod@4.4.2:
+    resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
+
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@biomejs/biome@2.4.13':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.13
+      '@biomejs/cli-darwin-x64': 2.4.13
+      '@biomejs/cli-linux-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64-musl': 2.4.13
+      '@biomejs/cli-linux-x64': 2.4.13
+      '@biomejs/cli-linux-x64-musl': 2.4.13
+      '@biomejs/cli-win32-arm64': 2.4.13
+      '@biomejs/cli-win32-x64': 2.4.13
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@iconify-json/ic@1.2.4':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/react@6.0.2(react@19.2.5)':
+    dependencies:
+      '@iconify/types': 2.0.0
+      react: 19.2.5
+
+  '@iconify/types@2.0.0': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@react-leaflet/core@3.0.0(leaflet@1.9.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      leaflet: 1.9.4
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.2
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
+
+  '@svgr/core@8.1.0(typescript@5.9.3)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      camelcase: 6.3.0
+      cosmiconfig: 8.3.6(typescript@5.9.3)
+      snake-case: 3.0.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@svgr/hast-util-to-babel-ast@8.0.0':
+    dependencies:
+      '@babel/types': 7.29.0
+      entities: 4.5.0
+
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/hast-util-to-babel-ast': 8.0.0
+      svg-parser: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tailwindcss/node@4.2.4':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.1
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.4
+
+  '@tailwindcss/oxide-android-arm64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.4':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.4
+      '@tailwindcss/oxide-darwin-arm64': 4.2.4
+      '@tailwindcss/oxide-darwin-x64': 4.2.4
+      '@tailwindcss/oxide-freebsd-x64': 4.2.4
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.4
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.4
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.4
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.4
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.4
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.4
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.4
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.4
+
+  '@tailwindcss/vite@4.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.2.4
+      '@tailwindcss/oxide': 4.2.4
+      tailwindcss: 4.2.4
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
+
+  '@types/leaflet@1.9.21':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  argparse@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  axios@1.16.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
+  baseline-browser-mapping@2.10.20: {}
+
+  bintrees@0.0.10: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.20
+      caniuse-lite: 1.0.30001788
+      electron-to-chromium: 1.5.340
+      node-releases: 2.0.37
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bson@0.1.8: {}
+
+  bson@0.1.9: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  callsites@3.1.0: {}
+
+  camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001788: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  cosmiconfig@8.3.6(typescript@5.9.3):
+    dependencies:
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  delayed-stream@1.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  electron-to-chromium@1.5.340: {}
+
+  enhanced-resolve@5.20.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.2
+
+  entities@4.5.0: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  escalade@3.2.0: {}
+
+  estree-walker@2.0.2: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  framer-motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  is-arrayish@0.2.1: {}
+
+  jiti@2.6.1: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsesc@3.1.0: {}
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  json5@2.2.3: {}
+
+  leaflet@1.9.4: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lines-and-columns@1.2.4: {}
+
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mongodb@1.2.14:
+    dependencies:
+      bson: 0.1.8
+
+  motion-dom@12.38.0:
+    dependencies:
+      motion-utils: 12.36.0
+
+  motion-utils@12.36.0: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
+
+  node-releases@2.0.37: {}
+
+  node-uuid@1.3.3: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  path-type@4.0.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  proxy-from-env@2.1.0: {}
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-hook-form@7.75.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
+  react-leaflet@5.0.0(leaflet@1.9.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@react-leaflet/core': 3.0.0(leaflet@1.9.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      leaflet: 1.9.4
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  react-refresh@0.18.0: {}
+
+  react-router-dom@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-router: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  react-router@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.5
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+
+  react@19.2.5: {}
+
+  resolve-from@4.0.0: {}
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  shared@0.2.0:
+    dependencies:
+      bintrees: 0.0.10
+      bson: 0.1.9
+      mongodb: 1.2.14
+      node-uuid: 1.3.3
+      underscore: 1.4.4
+
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
+
+  source-map-js@1.2.1: {}
+
+  svg-parser@2.0.4: {}
+
+  tailwindcss@4.2.4: {}
+
+  tapable@2.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.3: {}
+
+  underscore@1.4.4: {}
+
+  undici-types@7.16.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite-plugin-svgr@5.2.0(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - typescript
+
+  vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+
+  yallist@3.1.1: {}
+
+  yet-another-react-lightbox@3.31.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  zod@4.4.2: {}
+
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.5):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5

--- a/frontend/src/components/general/DmsSidebar.tsx
+++ b/frontend/src/components/general/DmsSidebar.tsx
@@ -9,7 +9,7 @@ const DmsSidebar: FunctionComponent = () => {
   const [searchQuery, setSearchQuery] = useState('');
 
   return (
-    <div className="w-72 h-screen relative overflow-hidden flex flex-col items-start py-10 pl-4 pr-3 box-border gap-2 text-left font-inter bg-white shadow-[4px_0_24px_rgba(0,0,0,0.02)]">
+    <div className="w-72 h-screen relative overflow-hidden flex flex-col items-start py-10 pl-4 pr-3 box-border gap-2 text-left font-inter bg-white shadow-[4px_0_24px_rgba(0,0,0,0.02)] dark:bg-[#121212] dark:text-gray-100 dark:shadow-[4px_0_24px_rgba(0,0,0,0.25)]">
       <div className="w-full flex flex-col items-start gap-8">
         {/* Header & Search */}
         <div className="w-full flex items-center gap-2 text-[0.875rem]">
@@ -18,7 +18,7 @@ const DmsSidebar: FunctionComponent = () => {
             className="w-8 h-8 cursor-pointer shrink-0 hover:text-teal transition-colors"
             onClick={() => navigate(-1)}
           />
-          <div className="flex-1 px-3 py-2 rounded-num-8 bg-unavailable_action flex items-center gap-2 transition-all focus-within:ring-1 focus-within:ring-teal/30 focus-within:bg-white focus-within:shadow-sm">
+          <div className="flex-1 px-3 py-2 rounded-num-8 bg-unavailable_action flex items-center gap-2 transition-all focus-within:ring-1 focus-within:ring-teal/30 focus-within:bg-white focus-within:shadow-sm dark:bg-[#1e1e1e] dark:focus-within:bg-[#2a2a2a]">
             <Icon icon="material-symbols:search" className="w-4 h-4 text-unselected shrink-0" />
             <input
               type="text"
@@ -26,7 +26,7 @@ const DmsSidebar: FunctionComponent = () => {
               value={searchQuery}
               maxLength={50}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full bg-transparent border-none outline-none text-num-14 font-medium text-darkgreen placeholder:text-unselected"
+              className="w-full bg-transparent border-none outline-none text-num-14 font-medium text-darkgreen placeholder:text-unselected dark:text-gray-200 dark:placeholder:text-gray-400"
             />
           </div>
         </div>
@@ -34,7 +34,7 @@ const DmsSidebar: FunctionComponent = () => {
         {/* Notifications Section */}
         <div className="self-stretch flex flex-col items-start gap-2 font-lora">
           <div className="self-stretch flex items-center justify-between py-1 font-inter">
-            <b className="relative flex items-start pl-2 text-num-18 text-[#2d3748]">
+            <b className="relative flex items-start pl-2 text-num-18 text-[#2d3748] dark:text-gray-100">
               Notifications
             </b>
             <span className="bg-teal/10 text-teal text-[10px] font-bold px-2 py-0.5 rounded-full">
@@ -73,7 +73,7 @@ const DmsSidebar: FunctionComponent = () => {
         {/* Direct Messages Section */}
         <div className="h-fit w-full flex flex-col items-start gap-4 font-lora">
           <div className="self-stretch flex items-end py-1 font-inter">
-            <b className="w-full flex-1 relative flex items-start text-num-18 pl-2 text-[#2d3748]">
+            <b className="w-full flex-1 relative flex items-start text-num-18 pl-2 text-[#2d3748] dark:text-gray-100">
               Direct Messages
             </b>
           </div>

--- a/frontend/src/components/landlord/LandlordFooter.tsx
+++ b/frontend/src/components/landlord/LandlordFooter.tsx
@@ -3,27 +3,27 @@ import AtlasLogo from '../../../assets/logo_atlas_text.svg?react';
 
 const LandlordFooter = () => {
   return (
-    <footer className="flex min-h-[80px] w-full items-center justify-center ">
+    <footer className="flex min-h-[80px] w-full items-center justify-center">
       <div className="flex w-full items-center justify-center px-[32px] py-[19px] xl:px-[80px]">
         <div className="flex w-full flex-wrap items-center justify-center gap-x-[48px] gap-y-[16px]">
           <div className="flex items-center gap-[16px]">
             <div className="flex items-center gap-[8px]">
               <AtlasLogo className="h-[42px] w-[48px]" aria-label="Atlas" />
               <div className="flex items-center gap-[12px]">
-                <span className="flex items-center gap-[4px] font-['Inter',sans-serif] text-[14px] font-bold text-[#666]">
+                <span className="flex items-center gap-[4px] font-['Inter',sans-serif] text-[14px] font-bold text-[#666] dark:text-gray-300">
                   <Icon icon="ph:copyright-bold" className="h-[20px] w-[20px]" aria-hidden="true" />
                   2026
                 </span>
-                <span className="font-['Inter',sans-serif] text-[14px] font-bold text-[#666]">
+                <span className="font-['Inter',sans-serif] text-[14px] font-bold text-[#666] dark:text-gray-300">
                   ATLAS Team
                 </span>
               </div>
             </div>
-            <span className="font-['Inter',sans-serif] text-[14px] font-bold text-[#666]">
+            <span className="font-['Inter',sans-serif] text-[14px] font-bold text-[#666] dark:text-gray-300">
               All Rights Reserved
             </span>
           </div>
-          <nav className="flex flex-col items-center justify-center gap-[10px] whitespace-nowrap font-['Inter',sans-serif] text-[14px] font-bold text-[#666]">
+          <nav className="flex flex-col items-center justify-center gap-[10px] whitespace-nowrap font-['Inter',sans-serif] text-[14px] font-bold text-[#666] dark:text-gray-300">
             <a href="#" className="hover:underline">
               Browse Dorms
             </a>
@@ -31,7 +31,7 @@ const LandlordFooter = () => {
               List your property
             </a>
           </nav>
-          <nav className="flex flex-col items-center justify-center gap-[10px] whitespace-nowrap font-['Inter',sans-serif] text-[14px] font-bold text-[#666]">
+          <nav className="flex flex-col items-center justify-center gap-[10px] whitespace-nowrap font-['Inter',sans-serif] text-[14px] font-bold text-[#666] dark:text-gray-300">
             <a href="#" className="hover:underline">
               About
             </a>
@@ -39,7 +39,7 @@ const LandlordFooter = () => {
               Contact Us
             </a>
           </nav>
-          <nav className="flex flex-col items-center justify-center gap-[10px] whitespace-nowrap font-['Inter',sans-serif] text-[14px] font-bold text-[#666]">
+          <nav className="flex flex-col items-center justify-center gap-[10px] whitespace-nowrap font-['Inter',sans-serif] text-[14px] font-bold text-[#666] dark:text-gray-300">
             <a href="#" className="hover:underline">
               Privacy Policy
             </a>

--- a/frontend/src/components/landlord/LandlordLayout.tsx
+++ b/frontend/src/components/landlord/LandlordLayout.tsx
@@ -24,7 +24,7 @@ const LandlordLayout = ({ activeSidebarItem, breadcrumbs = [], children }: Landl
   const [showHelp, setShowHelp] = useState(false);
 
   return (
-    <div className="relative min-h-screen">
+    <div className="relative min-h-screen text-[#001d18] dark:text-gray-100">
       <PageBackground />
       <div className="relative z-10 flex min-h-screen flex-col">
         <div className="flex flex-1 items-stretch">
@@ -52,13 +52,13 @@ const LandlordLayout = ({ activeSidebarItem, breadcrumbs = [], children }: Landl
                         {item.to ? (
                           <Link
                             to={item.to}
-                            className={`${labelClass} text-[#096c5b] hover:underline`}
+                            className={`${labelClass} text-[#096c5b] hover:underline dark:text-teal-100`}
                           >
                             {item.label}
                           </Link>
                         ) : (
                           <span
-                            className={`${labelClass} text-[#2f3136]`}
+                            className={`${labelClass} text-[#2f3136] dark:text-gray-200`}
                             aria-current={isLast ? 'page' : undefined}
                           >
                             {item.label}
@@ -67,7 +67,7 @@ const LandlordLayout = ({ activeSidebarItem, breadcrumbs = [], children }: Landl
                         {!isLast && (
                           <Icon
                             icon="iconamoon:arrow-right-2"
-                            className="h-[24px] w-[24px] text-[#2f3136]"
+                            className="h-[24px] w-[24px] text-[#2f3136] dark:text-gray-300"
                             aria-hidden="true"
                           />
                         )}

--- a/frontend/src/components/landlord/LandlordManagerActionsPopover.tsx
+++ b/frontend/src/components/landlord/LandlordManagerActionsPopover.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, type FunctionComponent } from 'react';
+import { Icon } from '@iconify/react';
+
+export type ManagerAction = 'message' | 'report' | 'remove';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onAction: (action: ManagerAction) => void;
+  managerName: string;
+};
+
+const items: Array<{
+  key: ManagerAction;
+  label: string;
+  icon: string;
+  danger?: boolean;
+}> = [
+  { key: 'message', label: 'Message', icon: 'ic:outline-mail' },
+  { key: 'report', label: 'Report', icon: 'solar:flag-bold' },
+  { key: 'remove', label: 'Remove', icon: 'solar:trash-bin-trash-bold', danger: true },
+];
+
+const LandlordManagerActionsPopover: FunctionComponent<Props> = ({
+  open,
+  onClose,
+  onAction,
+  managerName,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!ref.current) return;
+      if (ref.current.contains(event.target as Node)) return;
+      onClose();
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+
+    window.addEventListener('mousedown', handleClickOutside);
+    window.addEventListener('keydown', handleEscape);
+
+    return () => {
+      window.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('keydown', handleEscape);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      aria-label={`Actions for ${managerName}`}
+      onClick={(e) => e.stopPropagation()}
+      className="absolute left-full top-1/2 z-30 ml-[8px] flex w-[156px] -translate-y-1/2 flex-col gap-[2px] rounded-[10px] border border-solid border-[#f0f0f0] bg-white px-[6px] py-[6px] shadow-[0_8px_24px_rgba(0,0,0,0.12)] origin-left animate-fade-in"
+      style={{ animationDuration: '150ms' }}
+    >
+      {items.map((item) => (
+        <button
+          key={item.key}
+          type="button"
+          role="menuitem"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAction(item.key);
+          }}
+          className={[
+            'flex items-center gap-[10px] rounded-[8px] px-[10px] py-[8px] text-left transition-colors',
+            item.danger
+              ? 'text-[#dc2626] hover:bg-[#fef2f2]'
+              : 'text-[#2f3136] hover:bg-[#f0faf6]',
+          ].join(' ')}
+        >
+          <Icon icon={item.icon} className="h-[18px] w-[18px] shrink-0" aria-hidden="true" />
+          <span className="font-['Inter',sans-serif] text-[13px] font-semibold">{item.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default LandlordManagerActionsPopover;

--- a/frontend/src/components/landlord/LandlordManagerActionsPopover.tsx
+++ b/frontend/src/components/landlord/LandlordManagerActionsPopover.tsx
@@ -7,7 +7,8 @@ type Props = {
   open: boolean;
   onClose: () => void;
   onAction: (action: ManagerAction) => void;
-  managerName: string;
+  /** Display name for aria labels (tenant, manager, etc.). */
+  subjectName: string;
 };
 
 const items: Array<{
@@ -25,7 +26,7 @@ const LandlordManagerActionsPopover: FunctionComponent<Props> = ({
   open,
   onClose,
   onAction,
-  managerName,
+  subjectName,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -57,7 +58,7 @@ const LandlordManagerActionsPopover: FunctionComponent<Props> = ({
     <div
       ref={ref}
       role="menu"
-      aria-label={`Actions for ${managerName}`}
+      aria-label={`Actions for ${subjectName}`}
       onClick={(e) => e.stopPropagation()}
       className="absolute left-full top-1/2 z-30 ml-[8px] flex w-[156px] -translate-y-1/2 flex-col gap-[2px] rounded-[10px] border border-solid border-[#f0f0f0] bg-white px-[6px] py-[6px] shadow-[0_8px_24px_rgba(0,0,0,0.12)] origin-left animate-fade-in"
       style={{ animationDuration: '150ms' }}
@@ -73,9 +74,7 @@ const LandlordManagerActionsPopover: FunctionComponent<Props> = ({
           }}
           className={[
             'flex items-center gap-[10px] rounded-[8px] px-[10px] py-[8px] text-left transition-colors',
-            item.danger
-              ? 'text-[#dc2626] hover:bg-[#fef2f2]'
-              : 'text-[#2f3136] hover:bg-[#f0faf6]',
+            item.danger ? 'text-[#dc2626] hover:bg-[#fef2f2]' : 'text-[#2f3136] hover:bg-[#f0faf6]',
           ].join(' ')}
         >
           <Icon icon={item.icon} className="h-[18px] w-[18px] shrink-0" aria-hidden="true" />

--- a/frontend/src/components/landlord/LandlordManagerRemoveController.tsx
+++ b/frontend/src/components/landlord/LandlordManagerRemoveController.tsx
@@ -1,0 +1,51 @@
+import { type FunctionComponent, useEffect, useState } from 'react';
+import PortalPopup from './LandlordManagerPortal';
+import LandlordManagerRemoveConfirm from './LandlordManagerRemoveForms/LandlordManagerRemoveConfirm';
+import LandlordManagerRemoveSuccess from './LandlordManagerRemoveForms/LandlordManagerRemoveSuccess';
+
+type Manager = {
+  displayName: string;
+};
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  manager: Manager | null;
+};
+
+const RemoveManagerModal: FunctionComponent<Props> = ({ isOpen, onClose, manager }) => {
+  const [step, setStep] = useState<1 | 2>(1);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setStep(1);
+  }, [isOpen]);
+
+  if (!isOpen || !manager) return null;
+
+  const handleConfirm = () => {
+    // TODO: hook up actual removal once API is available.
+    console.log('=== Manager Remove Requested ===', manager.displayName);
+    setStep(2);
+  };
+
+  return (
+    <PortalPopup overlayColor="rgba(0, 0, 0, 0.25)" placement="Centered" onOutsideClick={onClose}>
+      <div key={step} className="animate-fade-in" style={{ animationDuration: '180ms' }}>
+        {step === 1 && (
+          <LandlordManagerRemoveConfirm
+            managerName={manager.displayName}
+            onCancel={onClose}
+            onConfirm={handleConfirm}
+          />
+        )}
+
+        {step === 2 && (
+          <LandlordManagerRemoveSuccess managerName={manager.displayName} onClose={onClose} />
+        )}
+      </div>
+    </PortalPopup>
+  );
+};
+
+export default RemoveManagerModal;

--- a/frontend/src/components/landlord/LandlordManagerRemoveForms/LandlordManagerRemoveConfirm.tsx
+++ b/frontend/src/components/landlord/LandlordManagerRemoveForms/LandlordManagerRemoveConfirm.tsx
@@ -1,0 +1,64 @@
+import type { FunctionComponent } from 'react';
+import { Icon } from '@iconify/react';
+
+type Props = {
+  managerName: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+const LandlordManagerRemoveConfirm: FunctionComponent<Props> = ({
+  managerName,
+  onCancel,
+  onConfirm,
+}) => {
+  return (
+    <div className="relative flex w-[480px] flex-col items-start overflow-hidden rounded-[16px] bg-white p-[32px]">
+      <div className="flex w-full flex-col items-center gap-[24px] overflow-hidden px-[10px] pt-[40px] pb-[16px]">
+        <div className="flex w-full flex-col items-start">
+          <div className="flex w-full items-center justify-center bg-white px-[3px] py-[5px]">
+            <div className="flex h-[100px] w-[100px] items-center justify-center rounded-full bg-[#fef2f2]">
+              <Icon
+                icon="solar:trash-bin-trash-bold"
+                className="h-[56px] w-[56px] text-[#dc2626]"
+                aria-hidden="true"
+              />
+            </div>
+          </div>
+
+          <div className="flex w-full flex-col items-center justify-center gap-[10px] p-[10px] text-center">
+            <b className="w-full font-['Inter',sans-serif] text-[24px] leading-[32px] text-black">
+              Remove Manager?
+            </b>
+            <p className="w-full font-['Inter',sans-serif] text-[14px] leading-[20px] font-medium text-black">
+              You are about to remove <b>{managerName}</b> as a manager. They will lose access to
+              all assigned properties and permissions.
+            </p>
+            <p className="w-full font-['Inter',sans-serif] text-[14px] leading-[20px] font-medium text-[#666]">
+              This action cannot be undone.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex w-full items-center justify-center gap-[12px] p-[10px]">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-[12px] px-[24px] py-[12px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#666] transition-opacity hover:opacity-70"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded-[12px] bg-[#fef2f2] px-[24px] py-[12px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#dc2626] transition-opacity hover:opacity-80"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LandlordManagerRemoveConfirm;

--- a/frontend/src/components/landlord/LandlordManagerRemoveForms/LandlordManagerRemoveSuccess.tsx
+++ b/frontend/src/components/landlord/LandlordManagerRemoveForms/LandlordManagerRemoveSuccess.tsx
@@ -1,0 +1,49 @@
+import type { FunctionComponent } from 'react';
+import { Icon } from '@iconify/react';
+
+type Props = {
+  managerName: string;
+  onClose: () => void;
+};
+
+const LandlordManagerRemoveSuccess: FunctionComponent<Props> = ({ managerName, onClose }) => {
+  return (
+    <div className="relative flex w-[480px] flex-col items-start overflow-hidden rounded-[16px] bg-white p-[32px]">
+      <div className="flex w-full flex-col items-center gap-[24px] overflow-hidden px-[10px] pt-[40px] pb-[24px]">
+        <div className="flex w-full flex-col items-start">
+          <div className="flex w-full items-center justify-center bg-white px-[3px] py-[5px]">
+            <div className="flex h-[100px] w-[100px] items-center justify-center rounded-full bg-[#cbf6ed]">
+              <Icon
+                icon="solar:check-circle-bold"
+                className="h-[64px] w-[64px] text-[#096c5b]"
+                aria-hidden="true"
+              />
+            </div>
+          </div>
+
+          <div className="flex w-full flex-col items-center justify-center gap-[10px] p-[10px] text-center">
+            <b className="w-full font-['Inter',sans-serif] text-[24px] leading-[32px] text-black">
+              Manager Removed.
+            </b>
+            <p className="w-full font-['Inter',sans-serif] text-[14px] leading-[20px] font-medium text-black">
+              <b>{managerName}</b> has been removed from your managers. They no longer have access
+              to your assigned properties.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex w-full flex-col items-center p-[10px]">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-[12px] bg-[#cbf6ed] px-[32px] py-[12px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#096c5b] transition-opacity hover:opacity-80"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LandlordManagerRemoveSuccess;

--- a/frontend/src/components/landlord/LandlordManagerReportController.tsx
+++ b/frontend/src/components/landlord/LandlordManagerReportController.tsx
@@ -1,26 +1,156 @@
-import { type FunctionComponent, useState } from 'react';
-import ReportManager1 from './LandlordManagerReportForms/ManagerReport1';
-import ReportManager2 from './LandlordManagerReportForms/ManagerReport2';
-import ReportManager3 from './LandlordManagerReportForms/ManagerReport3';
-import ReportManager4 from './LandlordManagerReportForms/ManagerReport4';
-import ReportManager5 from './LandlordManagerReportForms/ManagerReport5';
-import ReportManager6 from './LandlordManagerReportForms/ManagerReport6';
+import { type FunctionComponent, useEffect, useMemo, useState } from 'react';
 import PortalPopup from './LandlordManagerPortal';
+import LandlordManagerReportCategory, {
+  type ReportCategory,
+} from './LandlordManagerReportForms/LandlordManagerReportCategory';
+import LandlordManagerReportConfirm from './LandlordManagerReportForms/LandlordManagerReportConfirm';
+import LandlordManagerReportSuccess from './LandlordManagerReportForms/LandlordManagerReportSuccess';
+
+type Manager = {
+  displayName: string;
+  email: string;
+};
 
 type Props = {
   isOpen: boolean;
   onClose: () => void;
+  manager: Manager | null;
 };
 
-const ReportManagerModal: FunctionComponent<Props> = ({ isOpen, onClose }) => {
-  const [step, setStep] = useState(1);
+const REPORT_CATEGORIES: ReportCategory[] = [
+  {
+    key: 'admin',
+    title: 'Administrative & Management Issues',
+    items: [
+      {
+        key: 'admin_records',
+        title: 'Mismanagement of Tenant Records',
+        desc: 'Lost, incomplete, or falsified data',
+      },
+      {
+        key: 'admin_policy',
+        title: 'Failure to Enforce Dorm Policies',
+        desc: 'Ignoring curfews, guest rules, etc.',
+      },
+      {
+        key: 'admin_decisions',
+        title: 'Unauthorized Decision-Making',
+        desc: 'Acting without landlord approval',
+      },
+      {
+        key: 'admin_negligence',
+        title: 'Negligence in Duties',
+        desc: 'Not responding to tenant concerns or issues',
+      },
+      {
+        key: 'admin_conflict',
+        title: 'Conflict of Interest',
+        desc: 'Favoring certain tenants unfairly',
+      },
+    ],
+  },
+  {
+    key: 'financial',
+    title: 'Financial Misconduct',
+    items: [
+      {
+        key: 'fin_rent',
+        title: 'Rent Collection Irregularities',
+        desc: 'Delayed deposits, missing payments',
+      },
+      {
+        key: 'fin_charges',
+        title: 'Unauthorized Fees or Charges',
+        desc: "Collects payments not related to tenant's financial duties",
+      },
+      {
+        key: 'fin_funds',
+        title: 'Misuse of Funds',
+        desc: 'Maintenance funds, deposits, etc.',
+      },
+    ],
+  },
+  {
+    key: 'property',
+    title: 'Property & Maintenance Issues',
+    items: [
+      { key: 'prop_clean', title: 'Failure to Maintain Cleanliness' },
+      { key: 'prop_repair', title: 'Ignoring Repair Requests' },
+      { key: 'prop_staff', title: 'Improper Handling of Maintenance Staff' },
+      { key: 'prop_safety', title: 'Safety Hazards Not Addressed' },
+    ],
+  },
+  {
+    key: 'security',
+    title: 'Security & Safety Concerns',
+    items: [
+      { key: 'sec_access', title: 'Allowing Unauthorized Access' },
+      { key: 'sec_practices', title: 'Negligent Security Practices' },
+      { key: 'sec_incidents', title: 'Failure to Report Incidents' },
+      { key: 'sec_surveillance', title: 'Tampering with Surveillance Systems' },
+    ],
+  },
+];
+
+const ReportManagerModal: FunctionComponent<Props> = ({ isOpen, onClose, manager }) => {
+  // step 0..3 = categories; 4 = confirm; 5 = success
+  const [step, setStep] = useState(0);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setStep(0);
+    setSelected(new Set());
+  }, [isOpen]);
+
+  const totalCategorySteps = REPORT_CATEGORIES.length;
 
   const handleClose = () => {
-    setStep(1); // reset when closing
     onClose();
   };
 
-  if (!isOpen) return null;
+  const toggleItem = (itemKey: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(itemKey)) next.delete(itemKey);
+      else next.add(itemKey);
+      return next;
+    });
+  };
+
+  const toggleAllInCategory = (category: ReportCategory) => {
+    const allChecked = category.items.every((item) => selected.has(item.key));
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allChecked) {
+        category.items.forEach((item) => next.delete(item.key));
+      } else {
+        category.items.forEach((item) => next.add(item.key));
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = () => {
+    const selectedItems = REPORT_CATEGORIES.flatMap((c) =>
+      c.items.filter((i) => selected.has(i.key)).map((i) => ({ category: c.key, ...i })),
+    );
+
+    console.log('=== Manager Report Submitted ===');
+    console.log({
+      manager: manager?.email,
+      reports: selectedItems,
+    });
+
+    setStep(totalCategorySteps + 1);
+  };
+
+  const currentCategory = useMemo<ReportCategory | null>(() => {
+    if (step < 0 || step >= totalCategorySteps) return null;
+    return REPORT_CATEGORIES[step];
+  }, [step, totalCategorySteps]);
+
+  if (!isOpen || !manager) return null;
 
   return (
     <PortalPopup
@@ -28,17 +158,32 @@ const ReportManagerModal: FunctionComponent<Props> = ({ isOpen, onClose }) => {
       placement="Centered"
       onOutsideClick={handleClose}
     >
-      {step === 1 && <ReportManager1 onNext={() => setStep(2)} onCancel={handleClose} />}
+      <div key={step} className="animate-fade-in" style={{ animationDuration: '180ms' }}>
+        {currentCategory && (
+          <LandlordManagerReportCategory
+            managerName={manager.displayName}
+            managerEmail={manager.email}
+            category={currentCategory}
+            selected={selected}
+            isFirstStep={step === 0}
+            isLastCategory={step === totalCategorySteps - 1}
+            onToggle={toggleItem}
+            onToggleAll={() => toggleAllInCategory(currentCategory)}
+            onCancel={handleClose}
+            onBack={() => setStep((s) => Math.max(0, s - 1))}
+            onNext={() => setStep((s) => s + 1)}
+          />
+        )}
 
-      {step === 2 && <ReportManager2 onNext={() => setStep(3)} onCancel={handleClose} />}
+        {step === totalCategorySteps && (
+          <LandlordManagerReportConfirm
+            onBack={() => setStep((s) => s - 1)}
+            onSubmit={handleSubmit}
+          />
+        )}
 
-      {step === 3 && <ReportManager3 onNext={() => setStep(4)} onCancel={handleClose} />}
-
-      {step === 4 && <ReportManager4 onNext={() => setStep(5)} onCancel={handleClose} />}
-
-      {step === 5 && <ReportManager5 onSubmit={() => setStep(6)} onCancel={handleClose} />}
-
-      {step === 6 && <ReportManager6 onClose={handleClose} />}
+        {step === totalCategorySteps + 1 && <LandlordManagerReportSuccess onClose={handleClose} />}
+      </div>
     </PortalPopup>
   );
 };

--- a/frontend/src/components/landlord/LandlordManagerReportForms/LandlordManagerReportCategory.tsx
+++ b/frontend/src/components/landlord/LandlordManagerReportForms/LandlordManagerReportCategory.tsx
@@ -1,0 +1,220 @@
+import type { FunctionComponent, KeyboardEvent } from 'react';
+
+export type ReportItem = {
+  key: string;
+  title: string;
+  desc?: string;
+};
+
+export type ReportCategory = {
+  key: string;
+  title: string;
+  items: ReportItem[];
+};
+
+type Props = {
+  managerName: string;
+  managerEmail: string;
+  category: ReportCategory;
+  selected: Set<string>;
+  isFirstStep: boolean;
+  isLastCategory: boolean;
+  onToggle: (itemKey: string) => void;
+  onToggleAll: () => void;
+  onCancel: () => void;
+  onBack: () => void;
+  onNext: () => void;
+};
+
+const CheckSvg = ({ size = 14 }: { size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden
+  >
+    <path
+      d="M20 6L9 17l-5-5"
+      stroke="white"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const Checkbox: FunctionComponent<{ active: boolean; onToggle: () => void; ariaLabel?: string }> = ({
+  active,
+  onToggle,
+  ariaLabel,
+}) => (
+  <span
+    role="checkbox"
+    tabIndex={0}
+    aria-checked={active}
+    aria-label={ariaLabel}
+    onClick={(e) => {
+      e.stopPropagation();
+      onToggle();
+    }}
+    onKeyDown={(e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        onToggle();
+      }
+    }}
+    className={[
+      'inline-flex h-[24px] w-[24px] shrink-0 cursor-pointer items-center justify-center rounded-[4px] transition-colors',
+      active
+        ? 'bg-[#096c5b] shadow-[0_0_2px_rgba(0,0,0,0.25)]'
+        : 'bg-[#f0f0f0] shadow-[0_0_2px_rgba(0,0,0,0.25)]',
+    ].join(' ')}
+  >
+    {active ? <CheckSvg size={14} /> : null}
+  </span>
+);
+
+const LandlordManagerReportCategory: FunctionComponent<Props> = ({
+  managerName,
+  managerEmail,
+  category,
+  selected,
+  isFirstStep,
+  isLastCategory,
+  onToggle,
+  onToggleAll,
+  onCancel,
+  onBack,
+  onNext,
+}) => {
+  const allChecked = category.items.every((item) => selected.has(item.key));
+
+  return (
+    <div className="relative flex max-h-[90vh] w-[612px] flex-col items-center overflow-hidden rounded-[26px] bg-white">
+      {/* Header */}
+      <div
+        className="flex w-full flex-col items-start justify-center pl-[57px] pr-[32px] py-[12px]"
+        style={{
+          backgroundImage:
+            'linear-gradient(180.76181469696922deg, rgb(9, 108, 91) 1.4032%, rgb(22, 145, 124) 96.96%)',
+        }}
+      >
+        <div className="flex w-full flex-col items-start justify-center pb-[8px] pt-[32px]">
+          <b className="font-['Poppins',sans-serif] text-[32px] leading-[normal] text-white">
+            Report Manager
+          </b>
+          <b className="font-['Inter',sans-serif] text-[18px] leading-[normal] tracking-[-0.18px] text-[#f1f5f9]">
+            Report your dorm manager
+          </b>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex w-full flex-1 flex-col gap-[48px] overflow-y-auto px-[48px] pt-[32px] pb-[20px]">
+        <div className="flex w-full flex-col gap-[12px]">
+          <span className="font-['Inter',sans-serif] text-[14px] font-bold text-[#666]">
+            Email Address
+          </span>
+          <div className="flex h-[48px] w-full items-center rounded-[12px] border border-solid border-[#f0f0f0] px-[16px] py-[4px]">
+            <span className="font-['Inter',sans-serif] text-[14px] font-medium leading-[24px] text-[#64748b]">
+              {managerEmail}
+            </span>
+          </div>
+          <div className="flex w-full items-center justify-center px-[8px]">
+            <p className="flex-1 font-['Inter',sans-serif] text-[18px] font-bold leading-[normal] tracking-[-0.18px] text-black">
+              You are reporting {managerName}. Please select all that apply:
+            </p>
+          </div>
+        </div>
+
+        <div className="flex w-full flex-col gap-[12px]">
+          <div className="flex w-full items-end pr-[22px]">
+            <span className="flex-1 font-['Inter',sans-serif] text-[14px] font-bold text-[#666]">
+              {category.title}
+            </span>
+            <div className="flex items-center gap-[11px]">
+              <span className="font-['Inter',sans-serif] text-[12px] font-medium text-[#64748b]">
+                Select All
+              </span>
+              <Checkbox
+                active={allChecked}
+                onToggle={onToggleAll}
+                ariaLabel={`Select all in ${category.title}`}
+              />
+            </div>
+          </div>
+
+          <div className="flex w-full flex-col gap-[8px]">
+            {category.items.map((item) => {
+              const active = selected.has(item.key);
+              const hasDesc = !!item.desc;
+              return (
+                <div
+                  key={item.key}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => onToggle(item.key)}
+                  onKeyDown={(e: KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      onToggle(item.key);
+                    }
+                  }}
+                  className={[
+                    'flex w-full cursor-pointer items-center gap-[16px] rounded-[12px] py-[12px] pl-[24px] pr-[22px] text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#096c5b]/40',
+                    active ? 'bg-[#f0fdf9]' : 'hover:bg-[#fafafa]',
+                  ].join(' ')}
+                >
+                  <div className="flex flex-1 flex-col gap-[4px]">
+                    <span className="font-['Inter',sans-serif] text-[14px] font-bold text-black">
+                      {item.title}
+                    </span>
+                    {hasDesc && (
+                      <span className="font-['Inter',sans-serif] text-[12px] font-medium text-[#666]">
+                        {item.desc}
+                      </span>
+                    )}
+                  </div>
+                  <Checkbox active={active} onToggle={() => onToggle(item.key)} ariaLabel={item.title} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex w-full items-center justify-center gap-[16px] pb-[32px] pt-[16px]">
+        {isFirstStep ? (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-[12px] px-[24px] py-[8px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#ef4444] transition-opacity hover:opacity-70"
+          >
+            Cancel
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onBack}
+            className="rounded-[12px] px-[24px] py-[8px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#666] transition-opacity hover:opacity-70"
+          >
+            Back
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onNext}
+          className="rounded-[12px] bg-[#cbf6ed] px-[24px] py-[8px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#096c5b] transition-opacity hover:opacity-80"
+        >
+          {isLastCategory ? 'Continue' : 'Next'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LandlordManagerReportCategory;

--- a/frontend/src/components/landlord/LandlordManagerReportForms/LandlordManagerReportConfirm.tsx
+++ b/frontend/src/components/landlord/LandlordManagerReportForms/LandlordManagerReportConfirm.tsx
@@ -1,0 +1,107 @@
+import { useState, type FunctionComponent } from 'react';
+
+type Props = {
+  onBack: () => void;
+  onSubmit: () => void;
+};
+
+const LandlordManagerReportConfirm: FunctionComponent<Props> = ({ onBack, onSubmit }) => {
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  const handleSubmit = () => {
+    if (!acknowledged) return;
+    onSubmit();
+  };
+
+  return (
+    <div className="relative flex w-[612px] flex-col items-center overflow-hidden rounded-[26px] bg-white">
+      {/* Header */}
+      <div
+        className="flex w-full flex-col items-start justify-center pl-[57px] pr-[32px] py-[12px]"
+        style={{
+          backgroundImage:
+            'linear-gradient(180.76181469696922deg, rgb(9, 108, 91) 1.4032%, rgb(22, 145, 124) 96.96%)',
+        }}
+      >
+        <div className="flex w-full flex-col items-start justify-center pb-[8px] pt-[32px]">
+          <b className="font-['Poppins',sans-serif] text-[32px] leading-[normal] text-white">
+            Report Manager
+          </b>
+          <b className="font-['Inter',sans-serif] text-[18px] leading-[normal] tracking-[-0.18px] text-[#f1f5f9]">
+            Report your dorm manager
+          </b>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex w-full flex-col items-start gap-[24px] px-[48px] pt-[40px] pb-[24px]">
+        <div className="flex w-full items-start justify-center gap-[10px] px-[8px]">
+          <button
+            type="button"
+            role="checkbox"
+            aria-checked={acknowledged}
+            aria-label="I declare the report is truthful"
+            onClick={() => setAcknowledged((p) => !p)}
+            className={[
+              'mt-[4px] flex h-[20px] w-[20px] shrink-0 items-center justify-center rounded-[4px] transition-colors',
+              acknowledged
+                ? 'bg-[#096c5b] shadow-[0_0_2px_rgba(0,0,0,0.25)]'
+                : 'bg-[#f0f0f0] shadow-[0_0_2px_rgba(0,0,0,0.25)]',
+            ].join(' ')}
+          >
+            {acknowledged && (
+              <svg
+                width={12}
+                height={12}
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden
+              >
+                <path
+                  d="M20 6L9 17l-5-5"
+                  stroke="white"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            )}
+          </button>
+          <p className="flex-1 text-center font-['Inter',sans-serif] text-[14px] font-medium leading-[25px] text-black">
+            I declare that all information and reports submitted are{' '}
+            <span className="font-bold text-[#096c5b]">truthful</span>,{' '}
+            <span className="font-bold text-[#096c5b]">complete</span>, and{' '}
+            <span className="font-bold text-[#096c5b]">based on verified facts</span> to the best of
+            my knowledge. I acknowledge that any false or misleading information may lead to
+            consequences in accordance with applicable rules and regulations.
+          </p>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex w-full items-center justify-center gap-[16px] pb-[32px] pt-[8px]">
+        <button
+          type="button"
+          onClick={onBack}
+          className="rounded-[12px] px-[24px] py-[8px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#ef4444] transition-opacity hover:opacity-70"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!acknowledged}
+          className={[
+            'rounded-[12px] bg-[#cbf6ed] px-[24px] py-[8px] font-["Inter",sans-serif] text-[14px] font-semibold text-[#096c5b] transition-opacity',
+            acknowledged ? 'hover:opacity-80' : 'cursor-not-allowed opacity-50',
+          ].join(' ')}
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LandlordManagerReportConfirm;

--- a/frontend/src/components/landlord/LandlordManagerReportForms/LandlordManagerReportSuccess.tsx
+++ b/frontend/src/components/landlord/LandlordManagerReportForms/LandlordManagerReportSuccess.tsx
@@ -1,0 +1,52 @@
+import type { FunctionComponent } from 'react';
+import { Icon } from '@iconify/react';
+
+type Props = {
+  onClose: () => void;
+};
+
+const LandlordManagerReportSuccess: FunctionComponent<Props> = ({ onClose }) => {
+  return (
+    <div className="relative flex w-[480px] flex-col items-start overflow-hidden rounded-[16px] bg-white p-[32px]">
+      <div className="flex w-full flex-col items-center gap-[24px] overflow-hidden px-[10px] pt-[40px] pb-[24px]">
+        <div className="flex w-full flex-col items-start">
+          <div className="flex w-full items-center justify-center bg-white px-[3px] py-[5px]">
+            <div className="flex h-[100px] w-[100px] items-center justify-center rounded-full bg-[#cbf6ed]">
+              <Icon
+                icon="solar:check-circle-bold"
+                className="h-[64px] w-[64px] text-[#096c5b]"
+                aria-hidden="true"
+              />
+            </div>
+          </div>
+
+          <div className="flex w-full flex-col items-center justify-center gap-[10px] p-[10px] text-center">
+            <b className="w-full font-['Inter',sans-serif] text-[24px] leading-[32px] text-black">
+              Report Submitted.
+            </b>
+            <p className="w-full font-['Inter',sans-serif] text-[14px] leading-[20px] font-medium text-black">
+              Thank you for your report. You're helping keep ATLAS safe for our{' '}
+              <span className="italic">mga iskolar ng bayan</span> and landlords.
+            </p>
+            <p className="w-full font-['Inter',sans-serif] text-[14px] leading-[20px] font-medium text-black">
+              Your report has been successfully submitted. Our team will review the details and
+              take appropriate action.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex w-full flex-col items-center p-[10px]">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-[12px] bg-[#cbf6ed] px-[32px] py-[12px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#096c5b] transition-opacity hover:opacity-80"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LandlordManagerReportSuccess;

--- a/frontend/src/components/landlord/SideBarLandlord.tsx
+++ b/frontend/src/components/landlord/SideBarLandlord.tsx
@@ -4,6 +4,7 @@ import { Icon } from '@iconify/react';
 import AtlasLogo from '../../../assets/logo_atlas_text.svg?react';
 import AtlasLogoMin from '../../../assets/atlas logo (for white bg).png';
 import SideBarLandlordButton from './SideBarLandlordButton';
+import { useTheme } from '../../pages/utilities/DarkMode';
 
 export type SideBarLandlordItemKey =
   | 'dashboard'
@@ -106,11 +107,21 @@ const SideBarLandlord = ({
   className = '',
 }: SideBarLandlordProps) => {
   const navigate = useNavigate();
+  const { isDark, toggle } = useTheme();
   const [internalHover, setInternalHover] = useState<SideBarLandlordItemKey>();
   const [collapsed, setCollapsed] = useState(false);
   const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
   const [profileMenuPlacement, setProfileMenuPlacement] = useState<'top' | 'bottom'>('top');
   const profileMenuRef = useRef<HTMLDivElement | null>(null);
+
+  const handleDarkModeToggle: MouseEventHandler<HTMLButtonElement> = (event) => {
+    if (onToggleDarkMode) {
+      onToggleDarkMode(event);
+      return;
+    }
+
+    toggle();
+  };
 
   const handleItemClick = (item: (typeof navItems)[number]) => {
     onItemClick ? onItemClick(item.key) : navigate(item.route);
@@ -181,7 +192,7 @@ const SideBarLandlord = ({
   return (
     <aside
       className={[
-        'relative flex h-full min-h-screen shrink-0 flex-col items-center gap-[32px] border border-solid border-[#f0f0f0] pt-[24px] pb-[30px] transition-[width] duration-200',
+        'relative flex h-full min-h-screen shrink-0 flex-col items-center gap-[32px] border border-solid border-[#f0f0f0] pt-[24px] pb-[30px] transition-[width] duration-200 dark:border-gray-700 dark:bg-[#121212] dark:text-white',
         w,
         className,
       ].join(' ')}
@@ -191,7 +202,7 @@ const SideBarLandlord = ({
         type="button"
         onClick={() => setCollapsed((c) => !c)}
         aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        className="absolute -right-[12px] top-[24px] z-10 flex h-[24px] w-[24px] items-center justify-center rounded-full border border-[#f0f0f0] bg-white shadow-sm text-[#666] transition-colors hover:text-[#096c5b]"
+        className="absolute -right-[12px] top-[24px] z-10 flex h-[24px] w-[24px] items-center justify-center rounded-full border border-[#f0f0f0] bg-white shadow-sm text-[#666] transition-colors hover:text-[#096c5b] dark:border-gray-700 dark:bg-[#1e1e1e] dark:text-gray-200"
       >
         <Icon
           icon={
@@ -228,10 +239,10 @@ const SideBarLandlord = ({
             <button
               type="button"
               onClick={onAddListing}
-              className="flex w-full cursor-pointer items-center overflow-hidden rounded-[100px] bg-[#f0f0f0] pl-[17px] pr-[12px] transition-colors duration-200 ease-in-out hover:bg-[#e6e6e6]"
+              className="flex w-full cursor-pointer items-center overflow-hidden rounded-[100px] bg-[#f0f0f0] pl-[17px] pr-[12px] transition-colors duration-200 ease-in-out hover:bg-[#e6e6e6] dark:bg-[#1e1e1e] dark:hover:bg-[#2a2a2a]"
             >
               <span className="flex flex-1 items-start overflow-hidden py-[10px]">
-                <span className="font-['Inter',sans-serif] text-[10px] font-semibold leading-normal whitespace-nowrap text-[#666]">
+                <span className="font-['Inter',sans-serif] text-[10px] font-semibold leading-normal whitespace-nowrap text-[#666] dark:text-gray-300">
                   Add New Listing
                 </span>
               </span>
@@ -258,7 +269,7 @@ const SideBarLandlord = ({
                 key={item.key}
                 onMouseEnter={() => setInternalHover(item.key)}
                 onMouseLeave={() => setInternalHover((p) => (p === item.key ? undefined : p))}
-                className="transition-colors duration-150 hover:bg-[#F0FAF6]"
+                className="transition-colors duration-150 hover:bg-[#F0FAF6] dark:hover:bg-[#1f2937]"
                 title={collapsed ? item.label : undefined}
               >
                 {collapsed ? (
@@ -268,7 +279,7 @@ const SideBarLandlord = ({
                     aria-label={item.label}
                     className={[
                       'flex h-[44px] w-full items-center justify-center',
-                      state === 'clicked' ? 'text-[#096c5b]' : 'text-[#666]',
+                      state === 'clicked' ? 'text-[#096c5b]' : 'text-[#666] dark:text-gray-300',
                     ].join(' ')}
                   >
                     <Icon icon={item.icon} className="h-[20px] w-[20px]" />
@@ -292,10 +303,10 @@ const SideBarLandlord = ({
         {/* Dark mode */}
         <button
           type="button"
-          onClick={onToggleDarkMode}
+          onClick={handleDarkModeToggle}
           aria-label="Toggle dark mode"
           className={[
-            'flex cursor-pointer items-center transition-colors hover:bg-[#F0FAF6]',
+            'flex cursor-pointer items-center transition-colors hover:bg-[#F0FAF6] dark:hover:bg-[#1f2937]',
             collapsed ? 'h-[44px] w-full justify-center' : 'w-[180px] gap-[24px] pr-[20px]',
           ].join(' ')}
         >
@@ -309,20 +320,20 @@ const SideBarLandlord = ({
             ].join(' ')}
           >
             <Icon
-              icon="gg:dark-mode"
-              className="h-[24px] w-[24px] shrink-0 text-[#001d18]"
+              icon={isDark ? 'ph:sun-bold' : 'ph:moon-bold'}
+              className="h-[24px] w-[24px] shrink-0 text-[#001d18] dark:text-white"
               aria-hidden="true"
             />
             {!collapsed && (
-              <span className="font-['Inter',sans-serif] text-[14px] font-semibold leading-normal text-[#001d18]">
-                Dark Mode
+              <span className="font-['Inter',sans-serif] text-[14px] font-semibold leading-normal text-[#001d18] dark:text-white">
+                {isDark ? 'Light Mode' : 'Dark Mode'}
               </span>
             )}
           </span>
         </button>
 
         <div className="flex w-full flex-col items-start px-[20px]">
-          <div className="h-[2px] w-full rounded-[100px] bg-[#f0f0f0]" />
+          <div className="h-[2px] w-full rounded-[100px] bg-[#f0f0f0] dark:bg-gray-700" />
         </div>
 
         {/* Profile with dropdown */}
@@ -330,7 +341,7 @@ const SideBarLandlord = ({
           {isProfileMenuOpen && !collapsed && (
             <div
               className={[
-                'absolute left-[20px] z-30 flex h-[68px] w-[171px] flex-col gap-[7px] rounded-[9px] border border-solid border-[#f0f0f0] bg-[#f7f7f7] px-[11px] py-[9px] shadow-[0_4px_18px_rgba(0,0,0,0.1)]',
+                'absolute left-[20px] z-30 flex h-[68px] w-[171px] flex-col gap-[7px] rounded-[9px] border border-solid border-[#f0f0f0] bg-[#f7f7f7] px-[11px] py-[9px] shadow-[0_4px_18px_rgba(0,0,0,0.1)] dark:border-gray-700 dark:bg-[#1e1e1e]',
                 profileMenuPlacement === 'bottom' ? 'top-full mt-[8px]' : 'bottom-full mb-[8px]',
               ].join(' ')}
             >
@@ -344,7 +355,7 @@ const SideBarLandlord = ({
               <button
                 type="button"
                 onClick={handleSignOutClick}
-                className="h-[21px] w-full cursor-pointer rounded-[9px] border border-solid border-[#f0f0f0] bg-white bg-gradient-to-b from-[#c00f0f] to-[#e44f4f] bg-clip-text text-center font-['Inter',sans-serif] text-[11px] font-medium text-transparent transition-colors duration-150 hover:bg-[#f9f9f9]"
+                className="h-[21px] w-full cursor-pointer rounded-[9px] border border-solid border-[#f0f0f0] bg-white bg-gradient-to-b from-[#c00f0f] to-[#e44f4f] bg-clip-text text-center font-['Inter',sans-serif] text-[11px] font-medium text-transparent transition-colors duration-150 hover:bg-[#f9f9f9] dark:border-gray-600 dark:bg-[#2a2a2a]"
               >
                 Log Out
               </button>
@@ -358,7 +369,7 @@ const SideBarLandlord = ({
             aria-expanded={isProfileMenuOpen}
             aria-label={`${user.name} profile`}
             className={[
-              'flex cursor-pointer items-center overflow-hidden py-[10px] transition-colors duration-200 ease-in-out hover:bg-[#F0FAF6]',
+              'flex cursor-pointer items-center overflow-hidden py-[10px] transition-colors duration-200 ease-in-out hover:bg-[#F0FAF6] dark:hover:bg-[#1f2937]',
               collapsed ? 'w-full justify-center' : 'w-full gap-[8px] pl-[32px] pr-[20px]',
             ].join(' ')}
           >

--- a/frontend/src/components/landlord/tenants/SubmittedDocumentCard.tsx
+++ b/frontend/src/components/landlord/tenants/SubmittedDocumentCard.tsx
@@ -2,11 +2,17 @@ import type { ReactNode } from 'react';
 import { Icon } from '@iconify/react';
 import type { SubmittedDocument } from '../../../data/landlordTenants';
 
+export type DocumentReviewStatus = 'pending' | 'approved' | 'rejected';
+
 type SubmittedDocumentCardProps = {
   document: SubmittedDocument;
   onView?: (document: SubmittedDocument) => void;
+  /** When false, only the view (eye) control is shown (validated tenant documents). Default true. */
+  showMoreMenu?: boolean;
   onMoreOptions?: (document: SubmittedDocument) => void;
   actionMenu?: ReactNode;
+  /** When set, shows status and hides the more menu for non-pending items. */
+  reviewStatus?: DocumentReviewStatus;
 };
 
 const kindIcon: Record<SubmittedDocument['kind'], string> = {
@@ -18,9 +24,13 @@ const kindIcon: Record<SubmittedDocument['kind'], string> = {
 const SubmittedDocumentCard = ({
   document,
   onView,
+  showMoreMenu = true,
   onMoreOptions,
   actionMenu,
+  reviewStatus = 'pending',
 }: SubmittedDocumentCardProps) => {
+  const menuAllowed = showMoreMenu && reviewStatus === 'pending';
+
   return (
     <div className="relative flex w-full flex-col items-start justify-center gap-[10px] overflow-hidden rounded-[16px] border border-solid border-[#f0f0f0] bg-white px-[32px] py-[10px]">
       <div className="flex w-full items-center justify-between pr-[24px]">
@@ -33,9 +43,24 @@ const SubmittedDocumentCard = ({
               {document.descriptor}
             </span>
           )}
+          {reviewStatus === 'approved' && (
+            <span className="rounded-full bg-[#e8f7f4] px-[10px] py-[2px] font-['Inter',sans-serif] text-[11px] font-bold text-[#096c5b]">
+              Approved
+            </span>
+          )}
+          {reviewStatus === 'rejected' && (
+            <span className="rounded-full bg-[#fef2f2] px-[10px] py-[2px] font-['Inter',sans-serif] text-[11px] font-bold text-[#dc2626]">
+              Rejected
+            </span>
+          )}
         </div>
 
-        <div className="flex w-[72px] shrink-0 items-center gap-[24px]">
+        <div
+          className={[
+            'flex shrink-0 items-center',
+            menuAllowed ? 'w-[72px] gap-[24px]' : 'w-[24px] justify-end',
+          ].join(' ')}
+        >
           <button
             type="button"
             onClick={() => onView?.(document)}
@@ -44,18 +69,20 @@ const SubmittedDocumentCard = ({
           >
             <Icon icon="iconamoon:eye" className="h-[24px] w-[24px]" aria-hidden="true" />
           </button>
-          <button
-            type="button"
-            onClick={() => onMoreOptions?.(document)}
-            aria-label={`More options for ${document.title}`}
-            className="flex h-[24px] w-[24px] cursor-pointer items-center justify-center text-[#2f3136] transition-colors hover:text-[#096c5b]"
-          >
-            <Icon
-              icon="qlementine-icons:menu-dots-16"
-              className="h-[24px] w-[24px]"
-              aria-hidden="true"
-            />
-          </button>
+          {menuAllowed && (
+            <button
+              type="button"
+              onClick={() => onMoreOptions?.(document)}
+              aria-label={`More options for ${document.title}`}
+              className="flex h-[24px] w-[24px] cursor-pointer items-center justify-center text-[#2f3136] transition-colors hover:text-[#096c5b]"
+            >
+              <Icon
+                icon="qlementine-icons:menu-dots-16"
+                className="h-[24px] w-[24px]"
+                aria-hidden="true"
+              />
+            </button>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/landlord/tenants/TenantCard.tsx
+++ b/frontend/src/components/landlord/tenants/TenantCard.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { Icon } from '@iconify/react';
 import type { PaymentStatus, Tenant } from '../../../data/landlordTenants';
@@ -35,52 +35,73 @@ const STATUS_MAP: Record<PaymentStatus, StatusDescriptor> = {
 type TenantCardProps = {
   tenant: Tenant;
   to: string;
-  onMoreOptions?: (tenant: Tenant) => void;
+  /** Whether the kebab actions menu is open (for `aria-expanded`). */
+  menuOpen?: boolean;
+  onKebabClick?: (tenant: Tenant) => void;
+  /** Popover anchored next to the kebab (e.g. Message / Report / Remove). */
+  actionMenu?: ReactNode;
 };
 
-const TenantCard = ({ tenant, to, onMoreOptions }: TenantCardProps) => {
+const TenantCard = ({
+  tenant,
+  to,
+  menuOpen = false,
+  onKebabClick,
+  actionMenu,
+}: TenantCardProps) => {
   const status = STATUS_MAP[tenant.billingStatus];
 
   const handleMore = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
-    onMoreOptions?.(tenant);
+    onKebabClick?.(tenant);
   };
 
   return (
-    <Link
-      to={to}
-      className="group flex w-full flex-col gap-[10px] rounded-[16px] border border-solid border-[#f0f0f0] bg-white p-[12px] transition-shadow duration-200 hover:shadow-[0_4px_12px_0_rgba(0,0,0,0.08)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#096c5b]/40"
-      aria-label={`View tenant ${tenant.displayName}`}
-    >
+    <div className="group flex w-full flex-col gap-[10px] rounded-[16px] border border-solid border-[#f0f0f0] bg-white p-[12px] shadow-none transition-shadow duration-200 hover:shadow-[0_4px_12px_0_rgba(0,0,0,0.08)] focus-within:ring-2 focus-within:ring-[#096c5b]/40">
       <div className="flex w-full items-center gap-[10px] px-[16px] py-[10px]">
-        <TenantAvatar photoUrl={tenant.photoUrl} name={tenant.displayName} size={72} />
-
-        <div className="flex min-w-0 flex-1 flex-col justify-center gap-[8px] px-[4px] py-[8px]">
-          <p className="truncate font-['Inter',sans-serif] text-[18px] font-bold tracking-[-0.18px] text-black">
-            {tenant.displayName}
-          </p>
-          <div className="flex flex-col gap-[4px] font-['Inter',sans-serif] text-[14px] font-medium text-[#666]">
-            <span className="truncate">{tenant.unit}</span>
-            <span className="truncate">{tenant.contactNumber}</span>
-          </div>
-        </div>
-
-        <button
-          type="button"
-          onClick={handleMore}
-          aria-label={`More options for ${tenant.displayName}`}
-          className="flex h-[32px] w-[28px] shrink-0 cursor-pointer items-center justify-center text-[#2f3136] transition-colors hover:text-[#096c5b]"
+        <Link
+          to={to}
+          className="flex min-w-0 flex-1 items-center gap-[10px] outline-none focus-visible:ring-2 focus-visible:ring-[#096c5b]/40 focus-visible:ring-offset-2"
+          aria-label={`View tenant ${tenant.displayName}`}
         >
-          <Icon
-            icon="iconamoon:menu-kebab-vertical"
-            className="h-[28px] w-[28px]"
-            aria-hidden="true"
-          />
-        </button>
+          <TenantAvatar photoUrl={tenant.photoUrl} name={tenant.displayName} size={72} />
+
+          <div className="flex min-w-0 flex-1 flex-col justify-center gap-[8px] px-[4px] py-[8px]">
+            <p className="truncate font-['Inter',sans-serif] text-[18px] font-bold tracking-[-0.18px] text-black">
+              {tenant.displayName}
+            </p>
+            <div className="flex flex-col gap-[4px] font-['Inter',sans-serif] text-[14px] font-medium text-[#666]">
+              <span className="truncate">{tenant.unit}</span>
+              <span className="truncate">{tenant.contactNumber}</span>
+            </div>
+          </div>
+        </Link>
+
+        <div className="relative shrink-0 self-start pt-[6px]">
+          <button
+            type="button"
+            onClick={handleMore}
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            aria-label={`More options for ${tenant.displayName}`}
+            className="flex h-[32px] w-[28px] cursor-pointer items-center justify-center text-[#2f3136] transition-colors hover:text-[#096c5b]"
+          >
+            <Icon
+              icon="iconamoon:menu-kebab-vertical"
+              className="h-[28px] w-[28px]"
+              aria-hidden="true"
+            />
+          </button>
+          {actionMenu}
+        </div>
       </div>
 
-      <div className="flex w-full items-center gap-[4px] p-[16px]">
+      <Link
+        to={to}
+        className="flex w-full items-center gap-[4px] p-[16px] outline-none focus-visible:ring-2 focus-visible:ring-[#096c5b]/40 focus-visible:ring-offset-2"
+        aria-label={`View billing for ${tenant.displayName}`}
+      >
         <div className="flex flex-1 flex-col gap-[4px]">
           <span
             className={[
@@ -103,8 +124,8 @@ const TenantCard = ({ tenant, to, onMoreOptions }: TenantCardProps) => {
         >
           <Icon icon={status.icon} className="h-[32px] w-[32px]" />
         </span>
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 };
 

--- a/frontend/src/components/landlord/tenants/TenantsToolbar.tsx
+++ b/frontend/src/components/landlord/tenants/TenantsToolbar.tsx
@@ -1,33 +1,91 @@
+import { useEffect, useId, useRef, useState, type FunctionComponent } from 'react';
 import { Icon } from '@iconify/react';
+import { type TenantListFilters, tenantFiltersActive } from '../../../utils/tenantListFilters';
 
 type TenantsToolbarProps = {
   eyebrow?: string;
   title: string;
   count?: number | string;
   countClassName?: string;
-  onSearch?: () => void;
-  filterLabel?: string;
-  onFilterClick?: () => void;
+  /** When set together with `onFilterChange`, shows the tenants filter panel (main My Tenants page). */
+  filter?: TenantListFilters;
+  onFilterChange?: (patch: Partial<TenantListFilters>) => void;
+  onResetFilters?: () => void;
 };
 
-const TenantsToolbar = ({
+const STATUS_OPTIONS: Array<{ value: TenantListFilters['status']; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'paid', label: 'Paid' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'overdue', label: 'Overdue' },
+];
+
+const SORT_OPTIONS: Array<{ value: TenantListFilters['sort']; label: string }> = [
+  { value: 'date-asc', label: 'Date — oldest first' },
+  { value: 'date-desc', label: 'Date — newest first' },
+  { value: 'amount-asc', label: 'Monthly rent — low to high' },
+  { value: 'amount-desc', label: 'Monthly rent — high to low' },
+];
+
+const TenantsToolbar: FunctionComponent<TenantsToolbarProps> = ({
   eyebrow,
   title,
   count,
   countClassName = 'text-[#096c5b]',
-  onSearch,
-  filterLabel = 'Recently Added',
-  onFilterClick,
-}: TenantsToolbarProps) => {
+  filter,
+  onFilterChange,
+  onResetFilters,
+}) => {
+  const showTenantFilters = filter !== undefined && onFilterChange !== undefined;
+
+  const panelId = useId();
+  const [panelOpen, setPanelOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const facilityInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!panelOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!wrapRef.current?.contains(event.target as Node)) {
+        setPanelOpen(false);
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setPanelOpen(false);
+    };
+
+    window.addEventListener('mousedown', handlePointerDown);
+    window.addEventListener('keydown', handleEscape);
+
+    return () => {
+      window.removeEventListener('mousedown', handlePointerDown);
+      window.removeEventListener('keydown', handleEscape);
+    };
+  }, [panelOpen]);
+
+  const openAndFocusFacility = () => {
+    setPanelOpen(true);
+    requestAnimationFrame(() => facilityInputRef.current?.focus());
+  };
+
+  const summaryLabel =
+    showTenantFilters && filter && tenantFiltersActive(filter) ? 'Filters · active' : 'Tenants filter';
+
+  const handleStatus = (value: TenantListFilters['status']) => {
+    onFilterChange?.({ status: value });
+  };
+
   return (
-    <div className="flex w-full items-center gap-[20px]">
+    <div className="flex w-full flex-col gap-[16px] sm:flex-row sm:items-start sm:gap-[20px]">
       <div className="flex min-w-0 flex-1 flex-col gap-[5px]">
         {eyebrow && (
           <span className="font-['Inter',sans-serif] text-[14px] font-bold text-[#666]">
             {eyebrow}
           </span>
         )}
-        <div className="flex items-center gap-[12px]">
+        <div className="flex flex-wrap items-center gap-[12px]">
           <span className="font-['Inter',sans-serif] text-[24px] font-bold leading-[32px] whitespace-nowrap text-black">
             {title}
           </span>
@@ -41,40 +99,159 @@ const TenantsToolbar = ({
               {count}
             </span>
           )}
+          {showTenantFilters && (
+            <button
+              type="button"
+              onClick={openAndFocusFacility}
+              aria-label={`Search facility for ${title.toLowerCase()}`}
+              className="flex h-[32px] w-[32px] cursor-pointer items-center justify-center text-[#2f3136] transition-colors hover:text-[#096c5b]"
+            >
+              <Icon
+                icon="material-symbols:search-rounded"
+                className="h-[24px] w-[24px]"
+                aria-hidden="true"
+              />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {showTenantFilters && filter && onFilterChange && (
+      <div className="relative shrink-0 sm:pr-[32px]" ref={wrapRef}>
+        <div className="flex h-[60px] items-center justify-end gap-[10px] py-[10px]">
+          <span className="font-['Inter',sans-serif] text-[14px] font-bold whitespace-nowrap text-black">
+            Filter:
+          </span>
           <button
             type="button"
-            onClick={onSearch}
-            aria-label={`Search ${title.toLowerCase()}`}
-            className="flex h-[32px] w-[32px] cursor-pointer items-center justify-center text-[#2f3136] transition-colors hover:text-[#096c5b]"
+            aria-expanded={panelOpen}
+            aria-controls={panelId}
+            aria-haspopup="dialog"
+            onClick={() => setPanelOpen((o) => !o)}
+            className="flex h-full min-h-[44px] cursor-pointer items-center justify-center gap-[10px] rounded-[16px] border border-solid border-[#f8fafc] bg-[#f8fafc] px-[12px] py-[8px] transition-colors duration-200 hover:bg-[#eef3f9]"
           >
+            <span className="font-['Inter',sans-serif] text-[14px] font-medium leading-[24px] whitespace-nowrap text-[#666]">
+              {summaryLabel}
+            </span>
             <Icon
-              icon="material-symbols:search-rounded"
-              className="h-[24px] w-[24px]"
+              icon="mdi-light:chevron-down"
+              className={['h-[24px] w-[24px] text-[#2f3136] transition-transform', panelOpen ? 'rotate-180' : ''].join(
+                ' ',
+              )}
               aria-hidden="true"
             />
           </button>
         </div>
-      </div>
 
-      <div className="flex h-[60px] shrink-0 items-center justify-end gap-[10px] pr-[32px] py-[10px]">
-        <span className="font-['Inter',sans-serif] text-[14px] font-bold whitespace-nowrap text-black">
-          Filter By:
-        </span>
-        <button
-          type="button"
-          onClick={onFilterClick}
-          className="flex h-full cursor-pointer items-center justify-center gap-[10px] rounded-[16px] border border-solid border-[#f8fafc] bg-[#f8fafc] px-[12px] py-[8px] transition-colors duration-200 hover:bg-[#eef3f9]"
-        >
-          <span className="font-['Inter',sans-serif] text-[14px] font-medium leading-[24px] whitespace-nowrap text-[#666]">
-            {filterLabel}
-          </span>
-          <Icon
-            icon="mdi-light:chevron-down"
-            className="h-[24px] w-[24px] text-[#2f3136]"
-            aria-hidden="true"
-          />
-        </button>
+        {panelOpen && (
+          <div
+            id={panelId}
+            role="dialog"
+            aria-label="Tenants filter"
+            className="absolute right-0 top-full z-40 mt-[4px] w-[min(100vw-32px,360px)] rounded-[16px] border border-solid border-[#f0f0f0] bg-white p-[16px] shadow-[0_12px_40px_rgba(0,0,0,0.12)]"
+          >
+            <div className="flex flex-col gap-[18px]">
+              <div className="flex flex-col gap-[8px]">
+                <span className="font-['Inter',sans-serif] text-[12px] font-bold uppercase tracking-wide text-[#666]">
+                  Status
+                </span>
+                <div className="flex flex-wrap gap-[8px]">
+                  {STATUS_OPTIONS.map((opt) => {
+                    const active = filter.status === opt.value;
+                    return (
+                      <button
+                        key={String(opt.value)}
+                        type="button"
+                        onClick={() => handleStatus(opt.value)}
+                        className={[
+                          'rounded-full px-[14px] py-[6px] font-["Inter",sans-serif] text-[13px] font-semibold transition-colors',
+                          active
+                            ? 'bg-[#096c5b] text-white'
+                            : 'bg-[#f3f4f6] text-[#374151] hover:bg-[#e5e7eb]',
+                        ].join(' ')}
+                      >
+                        {opt.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-[8px]">
+                <label
+                  htmlFor={`${panelId}-sort`}
+                  className="font-['Inter',sans-serif] text-[12px] font-bold uppercase tracking-wide text-[#666]"
+                >
+                  Sort
+                </label>
+                <div className="relative">
+                  <select
+                    id={`${panelId}-sort`}
+                    value={filter.sort}
+                    onChange={(e) =>
+                      onFilterChange({ sort: e.target.value as TenantListFilters['sort'] })
+                    }
+                    className="w-full appearance-none rounded-[12px] border border-solid border-[#f0f0f0] bg-white py-[10px] pr-[40px] pl-[14px] font-['Inter',sans-serif] text-[14px] font-medium text-[#2f3136] outline-none focus-visible:ring-2 focus-visible:ring-[#096c5b]/30"
+                  >
+                    {SORT_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                  <Icon
+                    icon="mdi-light:chevron-down"
+                    className="pointer-events-none absolute right-[10px] top-1/2 h-[22px] w-[22px] -translate-y-1/2 text-[#666]"
+                    aria-hidden
+                  />
+                </div>
+                <p className="font-['Inter',sans-serif] text-[11px] font-medium text-[#8a9099]">
+                  Amount uses each tenant&apos;s monthly base rent.
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-[8px]">
+                <label
+                  htmlFor={`${panelId}-facility`}
+                  className="font-['Inter',sans-serif] text-[12px] font-bold uppercase tracking-wide text-[#666]"
+                >
+                  Facility
+                </label>
+                <div className="flex items-center gap-[8px] rounded-[12px] border border-solid border-[#f0f0f0] bg-[#fafafa] px-[12px] py-[8px] transition-colors focus-within:border-[#096c5b]/40 focus-within:bg-white">
+                  <Icon
+                    icon="material-symbols:search-rounded"
+                    className="h-[20px] w-[20px] shrink-0 text-[#64748b]"
+                    aria-hidden
+                  />
+                  <input
+                    ref={facilityInputRef}
+                    id={`${panelId}-facility`}
+                    type="search"
+                    placeholder="Dorm or apartment name..."
+                    value={filter.facilityQuery}
+                    onChange={(e) => onFilterChange({ facilityQuery: e.target.value })}
+                    className="min-w-0 flex-1 bg-transparent font-['Inter',sans-serif] text-[14px] font-medium text-[#2f3136] outline-none placeholder:text-[#9ca3af]"
+                    autoComplete="off"
+                  />
+                </div>
+              </div>
+
+              {tenantFiltersActive(filter) && onResetFilters && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    onResetFilters();
+                  }}
+                  className="self-start font-['Inter',sans-serif] text-[13px] font-semibold text-[#096c5b] underline-offset-2 hover:underline"
+                >
+                  Reset filters
+                </button>
+              )}
+            </div>
+          </div>
+        )}
       </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/landlord/tenants/TenantsToolbar.tsx
+++ b/frontend/src/components/landlord/tenants/TenantsToolbar.tsx
@@ -11,6 +11,9 @@ type TenantsToolbarProps = {
   filter?: TenantListFilters;
   onFilterChange?: (patch: Partial<TenantListFilters>) => void;
   onResetFilters?: () => void;
+  /** Search validated tenants by display / full name (main list only). */
+  nameSearchQuery?: string;
+  onNameSearchChange?: (query: string) => void;
 };
 
 const STATUS_OPTIONS: Array<{ value: TenantListFilters['status']; label: string }> = [
@@ -35,13 +38,18 @@ const TenantsToolbar: FunctionComponent<TenantsToolbarProps> = ({
   filter,
   onFilterChange,
   onResetFilters,
+  nameSearchQuery = '',
+  onNameSearchChange,
 }) => {
   const showTenantFilters = filter !== undefined && onFilterChange !== undefined;
+  const showNameSearch = showTenantFilters && onNameSearchChange !== undefined;
 
   const panelId = useId();
   const [panelOpen, setPanelOpen] = useState(false);
+  const [nameSearchOpen, setNameSearchOpen] = useState(() => nameSearchQuery.trim().length > 0);
   const wrapRef = useRef<HTMLDivElement>(null);
   const facilityInputRef = useRef<HTMLInputElement>(null);
+  const nameInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!panelOpen) return;
@@ -65,9 +73,12 @@ const TenantsToolbar: FunctionComponent<TenantsToolbarProps> = ({
     };
   }, [panelOpen]);
 
-  const openAndFocusFacility = () => {
-    setPanelOpen(true);
-    requestAnimationFrame(() => facilityInputRef.current?.focus());
+  useEffect(() => {
+    if (nameSearchQuery.trim().length > 0) setNameSearchOpen(true);
+  }, [nameSearchQuery]);
+
+  const focusNameInput = () => {
+    requestAnimationFrame(() => nameInputRef.current?.focus());
   };
 
   const summaryLabel =
@@ -99,158 +110,181 @@ const TenantsToolbar: FunctionComponent<TenantsToolbarProps> = ({
               {count}
             </span>
           )}
-          {showTenantFilters && (
-            <button
-              type="button"
-              onClick={openAndFocusFacility}
-              aria-label={`Search facility for ${title.toLowerCase()}`}
-              className="flex h-[32px] w-[32px] cursor-pointer items-center justify-center text-[#2f3136] transition-colors hover:text-[#096c5b]"
-            >
-              <Icon
-                icon="material-symbols:search-rounded"
-                className="h-[24px] w-[24px]"
-                aria-hidden="true"
-              />
-            </button>
+          {showNameSearch && (
+            <>
+              <button
+                type="button"
+                onClick={() => {
+                  setNameSearchOpen((open) => {
+                    const next = !open;
+                    if (next) focusNameInput();
+                    return next;
+                  });
+                }}
+                aria-label="Search tenants by name"
+                aria-expanded={nameSearchOpen}
+                className="flex h-[32px] w-[32px] shrink-0 cursor-pointer items-center justify-center text-[#2f3136] transition-colors hover:text-[#096c5b]"
+              >
+                <Icon
+                  icon="material-symbols:search-rounded"
+                  className="h-[24px] w-[24px]"
+                  aria-hidden="true"
+                />
+              </button>
+              {nameSearchOpen && (
+                <div className="flex min-w-[200px] max-w-[min(100%,320px)] flex-1 basis-full sm:basis-[280px]">
+                  <input
+                    ref={nameInputRef}
+                    type="search"
+                    value={nameSearchQuery}
+                    onChange={(e) => onNameSearchChange?.(e.target.value)}
+                    placeholder="Search by tenant name..."
+                    aria-label="Filter tenants by name"
+                    className="h-[40px] w-full rounded-[12px] border border-solid border-[#f0f0f0] bg-[#fafafa] px-[14px] font-['Inter',sans-serif] text-[14px] font-medium text-[#2f3136] outline-none transition-colors focus:border-[#096c5b]/40 focus:bg-white"
+                  />
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>
 
       {showTenantFilters && filter && onFilterChange && (
-      <div className="relative shrink-0 sm:pr-[32px]" ref={wrapRef}>
-        <div className="flex h-[60px] items-center justify-end gap-[10px] py-[10px]">
-          <span className="font-['Inter',sans-serif] text-[14px] font-bold whitespace-nowrap text-black">
-            Filter:
-          </span>
-          <button
-            type="button"
-            aria-expanded={panelOpen}
-            aria-controls={panelId}
-            aria-haspopup="dialog"
-            onClick={() => setPanelOpen((o) => !o)}
-            className="flex h-full min-h-[44px] cursor-pointer items-center justify-center gap-[10px] rounded-[16px] border border-solid border-[#f8fafc] bg-[#f8fafc] px-[12px] py-[8px] transition-colors duration-200 hover:bg-[#eef3f9]"
-          >
-            <span className="font-['Inter',sans-serif] text-[14px] font-medium leading-[24px] whitespace-nowrap text-[#666]">
-              {summaryLabel}
+        <div className="relative shrink-0 sm:pr-[32px]" ref={wrapRef}>
+          <div className="flex h-[60px] items-center justify-end gap-[10px] py-[10px]">
+            <span className="font-['Inter',sans-serif] text-[14px] font-bold whitespace-nowrap text-black">
+              Filter:
             </span>
-            <Icon
-              icon="mdi-light:chevron-down"
-              className={['h-[24px] w-[24px] text-[#2f3136] transition-transform', panelOpen ? 'rotate-180' : ''].join(
-                ' ',
-              )}
-              aria-hidden="true"
-            />
-          </button>
-        </div>
-
-        {panelOpen && (
-          <div
-            id={panelId}
-            role="dialog"
-            aria-label="Tenants filter"
-            className="absolute right-0 top-full z-40 mt-[4px] w-[min(100vw-32px,360px)] rounded-[16px] border border-solid border-[#f0f0f0] bg-white p-[16px] shadow-[0_12px_40px_rgba(0,0,0,0.12)]"
-          >
-            <div className="flex flex-col gap-[18px]">
-              <div className="flex flex-col gap-[8px]">
-                <span className="font-['Inter',sans-serif] text-[12px] font-bold uppercase tracking-wide text-[#666]">
-                  Status
-                </span>
-                <div className="flex flex-wrap gap-[8px]">
-                  {STATUS_OPTIONS.map((opt) => {
-                    const active = filter.status === opt.value;
-                    return (
-                      <button
-                        key={String(opt.value)}
-                        type="button"
-                        onClick={() => handleStatus(opt.value)}
-                        className={[
-                          'rounded-full px-[14px] py-[6px] font-["Inter",sans-serif] text-[13px] font-semibold transition-colors',
-                          active
-                            ? 'bg-[#096c5b] text-white'
-                            : 'bg-[#f3f4f6] text-[#374151] hover:bg-[#e5e7eb]',
-                        ].join(' ')}
-                      >
-                        {opt.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              <div className="flex flex-col gap-[8px]">
-                <label
-                  htmlFor={`${panelId}-sort`}
-                  className="font-['Inter',sans-serif] text-[12px] font-bold uppercase tracking-wide text-[#666]"
-                >
-                  Sort
-                </label>
-                <div className="relative">
-                  <select
-                    id={`${panelId}-sort`}
-                    value={filter.sort}
-                    onChange={(e) =>
-                      onFilterChange({ sort: e.target.value as TenantListFilters['sort'] })
-                    }
-                    className="w-full appearance-none rounded-[12px] border border-solid border-[#f0f0f0] bg-white py-[10px] pr-[40px] pl-[14px] font-['Inter',sans-serif] text-[14px] font-medium text-[#2f3136] outline-none focus-visible:ring-2 focus-visible:ring-[#096c5b]/30"
-                  >
-                    {SORT_OPTIONS.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </select>
-                  <Icon
-                    icon="mdi-light:chevron-down"
-                    className="pointer-events-none absolute right-[10px] top-1/2 h-[22px] w-[22px] -translate-y-1/2 text-[#666]"
-                    aria-hidden
-                  />
-                </div>
-                <p className="font-['Inter',sans-serif] text-[11px] font-medium text-[#8a9099]">
-                  Amount uses each tenant&apos;s monthly base rent.
-                </p>
-              </div>
-
-              <div className="flex flex-col gap-[8px]">
-                <label
-                  htmlFor={`${panelId}-facility`}
-                  className="font-['Inter',sans-serif] text-[12px] font-bold uppercase tracking-wide text-[#666]"
-                >
-                  Facility
-                </label>
-                <div className="flex items-center gap-[8px] rounded-[12px] border border-solid border-[#f0f0f0] bg-[#fafafa] px-[12px] py-[8px] transition-colors focus-within:border-[#096c5b]/40 focus-within:bg-white">
-                  <Icon
-                    icon="material-symbols:search-rounded"
-                    className="h-[20px] w-[20px] shrink-0 text-[#64748b]"
-                    aria-hidden
-                  />
-                  <input
-                    ref={facilityInputRef}
-                    id={`${panelId}-facility`}
-                    type="search"
-                    placeholder="Dorm or apartment name..."
-                    value={filter.facilityQuery}
-                    onChange={(e) => onFilterChange({ facilityQuery: e.target.value })}
-                    className="min-w-0 flex-1 bg-transparent font-['Inter',sans-serif] text-[14px] font-medium text-[#2f3136] outline-none placeholder:text-[#9ca3af]"
-                    autoComplete="off"
-                  />
-                </div>
-              </div>
-
-              {tenantFiltersActive(filter) && onResetFilters && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    onResetFilters();
-                  }}
-                  className="self-start font-['Inter',sans-serif] text-[13px] font-semibold text-[#096c5b] underline-offset-2 hover:underline"
-                >
-                  Reset filters
-                </button>
-              )}
-            </div>
+            <button
+              type="button"
+              aria-expanded={panelOpen}
+              aria-controls={panelId}
+              aria-haspopup="dialog"
+              onClick={() => setPanelOpen((o) => !o)}
+              className="flex h-full min-h-[44px] cursor-pointer items-center justify-center gap-[10px] rounded-[16px] border border-solid border-[#f8fafc] bg-[#f8fafc] px-[12px] py-[8px] transition-colors duration-200 hover:bg-[#eef3f9]"
+            >
+              <span className="font-['Inter',sans-serif] text-[14px] font-medium leading-[24px] whitespace-nowrap text-[#666]">
+                {summaryLabel}
+              </span>
+              <Icon
+                icon="mdi-light:chevron-down"
+                className={[
+                  'h-[24px] w-[24px] text-[#2f3136] transition-transform',
+                  panelOpen ? 'rotate-180' : '',
+                ].join(' ')}
+                aria-hidden="true"
+              />
+            </button>
           </div>
-        )}
-      </div>
+
+          {panelOpen && (
+            <div
+              id={panelId}
+              role="dialog"
+              aria-label="Tenants filter"
+              className="absolute right-0 top-full z-40 mt-[4px] w-[min(100vw-32px,360px)] rounded-[16px] border border-solid border-[#f0f0f0] bg-white p-[16px] shadow-[0_12px_40px_rgba(0,0,0,0.12)]"
+            >
+              <div className="flex flex-col gap-[18px]">
+                <div className="flex flex-col gap-[8px]">
+                  <span className="font-['Inter',sans-serif] text-[12px] font-bold uppercase tracking-wide text-[#666]">
+                    Status
+                  </span>
+                  <div className="flex flex-wrap gap-[8px]">
+                    {STATUS_OPTIONS.map((opt) => {
+                      const active = filter.status === opt.value;
+                      return (
+                        <button
+                          key={String(opt.value)}
+                          type="button"
+                          onClick={() => handleStatus(opt.value)}
+                          className={[
+                            'rounded-full px-[14px] py-[6px] font-["Inter",sans-serif] text-[13px] font-semibold transition-colors',
+                            active
+                              ? 'bg-[#096c5b] text-white'
+                              : 'bg-[#f3f4f6] text-[#374151] hover:bg-[#e5e7eb]',
+                          ].join(' ')}
+                        >
+                          {opt.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-[8px]">
+                  <label
+                    htmlFor={`${panelId}-sort`}
+                    className="font-['Inter',sans-serif] text-[12px] font-bold uppercase tracking-wide text-[#666]"
+                  >
+                    Sort
+                  </label>
+                  <div className="relative">
+                    <select
+                      id={`${panelId}-sort`}
+                      value={filter.sort}
+                      onChange={(e) =>
+                        onFilterChange({ sort: e.target.value as TenantListFilters['sort'] })
+                      }
+                      className="w-full appearance-none rounded-[12px] border border-solid border-[#f0f0f0] bg-white py-[10px] pr-[40px] pl-[14px] font-['Inter',sans-serif] text-[14px] font-medium text-[#2f3136] outline-none focus-visible:ring-2 focus-visible:ring-[#096c5b]/30"
+                    >
+                      {SORT_OPTIONS.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                    <Icon
+                      icon="mdi-light:chevron-down"
+                      className="pointer-events-none absolute right-[10px] top-1/2 h-[22px] w-[22px] -translate-y-1/2 text-[#666]"
+                      aria-hidden
+                    />
+                  </div>
+                  <p className="font-['Inter',sans-serif] text-[11px] font-medium text-[#8a9099]">
+                    Amount uses each tenant&apos;s monthly base rent.
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-[8px]">
+                  <label
+                    htmlFor={`${panelId}-facility`}
+                    className="font-['Inter',sans-serif] text-[12px] font-bold uppercase tracking-wide text-[#666]"
+                  >
+                    Facility
+                  </label>
+                  <div className="flex items-center gap-[8px] rounded-[12px] border border-solid border-[#f0f0f0] bg-[#fafafa] px-[12px] py-[8px] transition-colors focus-within:border-[#096c5b]/40 focus-within:bg-white">
+                    <Icon
+                      icon="material-symbols:search-rounded"
+                      className="h-[20px] w-[20px] shrink-0 text-[#64748b]"
+                      aria-hidden
+                    />
+                    <input
+                      ref={facilityInputRef}
+                      id={`${panelId}-facility`}
+                      type="search"
+                      placeholder="Dorm or apartment name..."
+                      value={filter.facilityQuery}
+                      onChange={(e) => onFilterChange({ facilityQuery: e.target.value })}
+                      className="min-w-0 flex-1 bg-transparent font-['Inter',sans-serif] text-[14px] font-medium text-[#2f3136] outline-none placeholder:text-[#9ca3af]"
+                      autoComplete="off"
+                    />
+                  </div>
+                </div>
+
+                {tenantFiltersActive(filter) && onResetFilters && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onResetFilters();
+                    }}
+                    className="self-start font-['Inter',sans-serif] text-[13px] font-semibold text-[#096c5b] underline-offset-2 hover:underline"
+                  >
+                    Reset filters
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/landlord/tenants/popups/ApproveDocumentPopup.tsx
+++ b/frontend/src/components/landlord/tenants/popups/ApproveDocumentPopup.tsx
@@ -1,0 +1,68 @@
+import type { SubmittedDocument } from '../../../../data/landlordTenants';
+import PopupOverlay from './PopupOverlay';
+
+type ApproveDocumentPopupProps = {
+  document: SubmittedDocument | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+const ApproveDocumentPopup = ({
+  document,
+  isOpen,
+  onClose,
+  onConfirm,
+}: ApproveDocumentPopupProps) => {
+  if (!isOpen || !document) return null;
+
+  return (
+    <PopupOverlay onClose={onClose}>
+      <div className="flex w-[612px] max-h-[90vh] flex-col overflow-hidden rounded-tl-[32px] bg-white">
+        <div className="w-full shrink-0 rounded-tl-[32px] bg-linear-to-b from-[#096c5b] to-[#16917c] px-[57px] py-[12px]">
+          <div className="w-full py-[32px] pb-[8px]">
+            <h2 className="font-['Poppins',sans-serif] text-[32px] font-bold text-white">
+              Approve Document
+            </h2>
+            <p className="font-['Inter',sans-serif] text-[18px] font-bold tracking-[-0.18px] text-[#f1f5f9]">
+              Confirm document approval
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-[32px] px-[48px] pt-[32px] pb-[24px]">
+          <p className="font-['Inter',sans-serif] text-[18px] font-bold tracking-[-0.18px] text-[#001d18]">
+            Approve <span className="text-[#096c5b]">{document.title}</span>? This marks the
+            submission as verified for this applicant. You can still reject other documents
+            separately.
+          </p>
+          <p className="font-['Inter',sans-serif] text-[14px] font-medium text-[#666]">
+            File: <span className="font-bold text-[#2f3136]">{document.fileName}</span>
+          </p>
+        </div>
+
+        <div className="flex items-center justify-center gap-[16px] px-[48px] pb-[32px]">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-[12px] px-[24px] py-[8px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#ef4444] transition-opacity hover:opacity-80"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              onConfirm();
+              onClose();
+            }}
+            className="rounded-[12px] bg-[#cbf6ed] px-[24px] py-[8px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#096c5b] transition-opacity hover:opacity-80"
+          >
+            Confirm approval
+          </button>
+        </div>
+      </div>
+    </PopupOverlay>
+  );
+};
+
+export default ApproveDocumentPopup;

--- a/frontend/src/pages/landlord/managers/LandlordManagersList.tsx
+++ b/frontend/src/pages/landlord/managers/LandlordManagersList.tsx
@@ -4,12 +4,33 @@ import { Icon } from '@iconify/react';
 import LandlordLayout from '../../../components/landlord/LandlordLayout';
 import AddManager from '../../../components/landlord/LandlordManagerAddController';
 import ReportManager from '../../../components/landlord/LandlordManagerReportController';
-import { properties, managers } from '../../../data/landlordManagers';
+import RemoveManager from '../../../components/landlord/LandlordManagerRemoveController';
+import LandlordManagerActionsPopover, {
+  type ManagerAction,
+} from '../../../components/landlord/LandlordManagerActionsPopover';
+import { properties, managers, type Manager } from '../../../data/landlordManagers';
 
 const Managers = () => {
   const navigate = useNavigate();
   const [isAddManagerOpen, setAddManagerOpen] = useState(false);
-  const [isReportManagerOpen, setReportManagerOpen] = useState(false);
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [reportTarget, setReportTarget] = useState<Manager | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<Manager | null>(null);
+
+  const handleAction = (manager: Manager, action: ManagerAction) => {
+    setOpenMenuId(null);
+    if (action === 'message') {
+      navigate('/landlord/messages');
+      return;
+    }
+    if (action === 'report') {
+      setReportTarget(manager);
+      return;
+    }
+    if (action === 'remove') {
+      setRemoveTarget(manager);
+    }
+  };
 
   return (
     <LandlordLayout activeSidebarItem="managers" breadcrumbs={[{ label: 'Property Manager List' }]}>
@@ -53,52 +74,67 @@ const Managers = () => {
                   </p>
                 ) : (
                   <div className="flex flex-wrap gap-[24px]">
-                    {propertyManagers.map((manager) => (
-                      <div
-                        key={manager.id}
-                        onClick={() => navigate(`/landlord/managers/${manager.id}`)}
-                        className="flex w-[331px] cursor-pointer items-center justify-between rounded-[8px] px-[16px] py-[10px] transition-colors hover:bg-[#f9f9f9]"
-                      >
-                        <div className="flex items-center gap-[10px]">
-                          <span className="flex h-[48px] w-[48px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#e5e7eb] text-[#9ca3af]">
-                            {manager.photoUrl ? (
-                              <img
-                                src={manager.photoUrl}
-                                alt={manager.displayName}
-                                className="h-full w-full object-cover"
-                              />
-                            ) : (
+                    {propertyManagers.map((manager) => {
+                      const cardKey = `${property.id}-${manager.id}`;
+                      const menuOpen = openMenuId === cardKey;
+
+                      return (
+                        <div
+                          key={cardKey}
+                          onClick={() => navigate(`/landlord/managers/${manager.id}`)}
+                          className="flex w-[331px] cursor-pointer items-center justify-between rounded-[8px] px-[16px] py-[10px] transition-colors hover:bg-[#f9f9f9]"
+                        >
+                          <div className="flex items-center gap-[10px]">
+                            <span className="flex h-[48px] w-[48px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#e5e7eb] text-[#9ca3af]">
+                              {manager.photoUrl ? (
+                                <img
+                                  src={manager.photoUrl}
+                                  alt={manager.displayName}
+                                  className="h-full w-full object-cover"
+                                />
+                              ) : (
+                                <Icon
+                                  icon="solar:user-bold"
+                                  className="h-[28px] w-[28px]"
+                                  aria-hidden="true"
+                                />
+                              )}
+                            </span>
+                            <div className="flex flex-col gap-[2px]">
+                              <span className="font-['Inter',sans-serif] text-[16px] font-bold tracking-[-0.01em] text-black">
+                                {manager.displayName}
+                              </span>
+                              <span className="font-['Inter',sans-serif] text-[14px] text-[#666]">
+                                {manager.email}
+                              </span>
+                            </div>
+                          </div>
+                          <div className="relative">
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setOpenMenuId(menuOpen ? null : cardKey);
+                              }}
+                              aria-haspopup="menu"
+                              aria-expanded={menuOpen}
+                              aria-label={`More options for ${manager.displayName}`}
+                              className="flex items-center justify-center rounded-full p-[4px] transition-opacity hover:opacity-70"
+                            >
                               <Icon
-                                icon="solar:user-bold"
-                                className="h-[28px] w-[28px]"
-                                aria-hidden="true"
+                                icon="solar:menu-dots-bold"
+                                className="h-[20px] w-[20px] text-[#666]"
                               />
-                            )}
-                          </span>
-                          <div className="flex flex-col gap-[2px]">
-                            <span className="font-['Inter',sans-serif] text-[16px] font-bold tracking-[-0.01em] text-black">
-                              {manager.displayName}
-                            </span>
-                            <span className="font-['Inter',sans-serif] text-[14px] text-[#666]">
-                              {manager.email}
-                            </span>
+                            </button>
+                            <LandlordManagerActionsPopover
+                              open={menuOpen}
+                              onClose={() => setOpenMenuId(null)}
+                              onAction={(action) => handleAction(manager, action)}
+                              managerName={manager.displayName}
+                            />
                           </div>
                         </div>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setReportManagerOpen(true);
-                          }}
-                          aria-label={`More options for ${manager.displayName}`}
-                          className="flex items-center justify-center rounded-full p-[4px] transition-opacity hover:opacity-70"
-                        >
-                          <Icon
-                            icon="solar:menu-dots-bold"
-                            className="h-[20px] w-[20px] text-[#666]"
-                          />
-                        </button>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </section>
@@ -108,7 +144,16 @@ const Managers = () => {
       </div>
 
       <AddManager isOpen={isAddManagerOpen} onClose={() => setAddManagerOpen(false)} />
-      <ReportManager isOpen={isReportManagerOpen} onClose={() => setReportManagerOpen(false)} />
+      <ReportManager
+        isOpen={!!reportTarget}
+        onClose={() => setReportTarget(null)}
+        manager={reportTarget}
+      />
+      <RemoveManager
+        isOpen={!!removeTarget}
+        onClose={() => setRemoveTarget(null)}
+        manager={removeTarget}
+      />
     </LandlordLayout>
   );
 };

--- a/frontend/src/pages/landlord/managers/LandlordManagersList.tsx
+++ b/frontend/src/pages/landlord/managers/LandlordManagersList.tsx
@@ -129,7 +129,7 @@ const Managers = () => {
                               open={menuOpen}
                               onClose={() => setOpenMenuId(null)}
                               onAction={(action) => handleAction(manager, action)}
-                              managerName={manager.displayName}
+                              subjectName={manager.displayName}
                             />
                           </div>
                         </div>

--- a/frontend/src/pages/landlord/messages/LandlordMessages.tsx
+++ b/frontend/src/pages/landlord/messages/LandlordMessages.tsx
@@ -8,17 +8,19 @@ const LandlordMessages: FunctionComponent = () => {
   const [showHelp, setShowHelp] = useState(false);
 
   return (
-    <div className="w-full h-screen flex items-start font-inter overflow-hidden bg-white">
-      <div className="sticky top-0 h-full w-fit shrink-0 border-r border-whitesmoke">
+    <div className="w-full h-screen flex items-start font-inter overflow-hidden bg-white dark:bg-darkmode dark:text-gray-100">
+      <div className="sticky top-0 h-full w-fit shrink-0 border-r border-whitesmoke dark:border-gray-700">
         <DmsSidebar />
       </div>
       <TutorialBubble show={showHelp} onClose={() => setShowHelp(false)} />
-      <div className="bg-white flex-1 h-full flex flex-col items-center justify-center relative">
+      <div className="bg-white flex-1 h-full flex flex-col items-center justify-center relative dark:bg-darkmode">
         <div className="flex flex-col items-center gap-4">
           <img src={oswald} alt="No conversation selected" className="w-80 h-auto object-contain" />
           <div className="flex flex-col items-center gap-1">
-            <b className="text-num-18 text-darkslategray leading-tight">No conversation selected</b>
-            <p className="text-num-14s font-medium text-dimgray">
+            <b className="text-num-18 text-darkslategray leading-tight dark:text-gray-100">
+              No conversation selected
+            </b>
+            <p className="text-num-14s font-medium text-dimgray dark:text-gray-300">
               Select a tab to view specific message
             </p>
           </div>

--- a/frontend/src/pages/landlord/properties/AddBuilding.tsx
+++ b/frontend/src/pages/landlord/properties/AddBuilding.tsx
@@ -48,7 +48,7 @@ const AddBuilding: FunctionComponent = () => {
   ];
 
   return (
-    <div className="w-screen font-inter min-h-screen bg-white">
+    <div className="w-screen font-inter min-h-screen bg-white dark:bg-darkmode dark:text-gray-100">
       <div className="px-10 lg:px-20 pt-4 pb-12">
         <button
           type="button"
@@ -65,11 +65,11 @@ const AddBuilding: FunctionComponent = () => {
           </div>
         </button>
 
-        <div className="rounded-3xl border border-whitesmoke px-6 md:px-10 pt-8 pb-10 shadow-sm">
+        <div className="rounded-3xl border border-whitesmoke px-6 md:px-10 pt-8 pb-10 shadow-sm dark:border-gray-700 dark:bg-[#121212]">
           <h1 className="text-2xl font-bold" style={{ color: "#1a5c50" }}>
             Add a New Building
           </h1>
-          <p className="text-sm font-semibold text-black mt-1">
+          <p className="text-sm font-semibold text-black mt-1 dark:text-gray-100">
             Follow 3 simple steps and you're ready to go!
           </p>
 

--- a/frontend/src/pages/landlord/tenants/LandlordTenantDetail.tsx
+++ b/frontend/src/pages/landlord/tenants/LandlordTenantDetail.tsx
@@ -90,7 +90,11 @@ const LandlordTenantDetail = () => {
           ) : (
             <div className="flex flex-col gap-[12px] px-[32px]">
               {tenant.documents.map((document) => (
-                <SubmittedDocumentCard key={document.id} document={document} />
+                <SubmittedDocumentCard
+                  key={document.id}
+                  document={document}
+                  showMoreMenu={false}
+                />
               ))}
             </div>
           )}

--- a/frontend/src/pages/landlord/tenants/LandlordTenants.tsx
+++ b/frontend/src/pages/landlord/tenants/LandlordTenants.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Icon } from '@iconify/react';
 import LandlordLayout from '../../../components/landlord/LandlordLayout';
@@ -6,15 +6,22 @@ import TenantsToolbar from '../../../components/landlord/tenants/TenantsToolbar'
 import TenantCard from '../../../components/landlord/tenants/TenantCard';
 import RemoveTenantPopup from '../../../components/landlord/tenants/popups/RemoveTenantPopup';
 import {
-  TENANT_COUNT,
-  pendingApplications,
-  tenants,
-  type Tenant,
-} from '../../../data/landlordTenants';
+  defaultTenantListFilters,
+  filterAndSortTenants,
+  tenantFiltersActive,
+} from '../../../utils/tenantListFilters';
+import { pendingApplications, tenants, type Tenant } from '../../../data/landlordTenants';
 
 const LandlordTenants = () => {
   const pendingCount = pendingApplications.length;
   const [removeTarget, setRemoveTarget] = useState<Tenant | null>(null);
+  const [filters, setFilters] = useState(defaultTenantListFilters);
+
+  const filteredTenants = useMemo(() => filterAndSortTenants(tenants, filters), [filters]);
+
+  const patchFilters = (patch: Partial<typeof filters>) => {
+    setFilters((prev) => ({ ...prev, ...patch }));
+  };
 
   return (
     <LandlordLayout activeSidebarItem="tenants" breadcrumbs={[{ label: 'My Tenants' }]}>
@@ -23,8 +30,11 @@ const LandlordTenants = () => {
           <TenantsToolbar
             eyebrow="My Tenants"
             title="Tenants"
-            count={TENANT_COUNT}
+            count={filteredTenants.length}
             countClassName="text-[#096c5b]"
+            filter={filters}
+            onFilterChange={patchFilters}
+            onResetFilters={() => setFilters(defaultTenantListFilters)}
           />
           <div className="h-[2px] w-full rounded-[100px] bg-[#f0f0f0]" />
 
@@ -62,12 +72,35 @@ const LandlordTenants = () => {
               Validated tenants will appear here.
             </p>
           </div>
+        ) : filteredTenants.length === 0 ? (
+          <div className="flex min-h-[280px] w-full flex-col items-center justify-center gap-[16px] rounded-[16px] border border-dashed border-[#f0f0f0] bg-white p-[32px] text-center">
+            <Icon
+              icon="material-symbols:filter-alt-off"
+              className="h-[40px] w-[40px] text-[#64748b]"
+              aria-hidden="true"
+            />
+            <p className="font-['Inter',sans-serif] text-[16px] font-bold text-[#2f3136]">
+              No tenants match your filters
+            </p>
+            <p className="font-['Inter',sans-serif] text-[14px] text-[#666]">
+              Try a different status, sort, or facility search.
+            </p>
+            {tenantFiltersActive(filters) && (
+              <button
+                type="button"
+                onClick={() => setFilters(defaultTenantListFilters)}
+                className="rounded-[12px] bg-[#cbf6ed] px-[24px] py-[10px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#096c5b] transition-opacity hover:opacity-80"
+              >
+                Reset filters
+              </button>
+            )}
+          </div>
         ) : (
           <section
             aria-label="Tenants grid"
             className="grid w-full grid-cols-1 gap-x-[24px] gap-y-[32px] sm:grid-cols-2 xl:grid-cols-3"
           >
-            {tenants.map((tenant) => (
+            {filteredTenants.map((tenant) => (
               <TenantCard
                 key={tenant.id}
                 tenant={tenant}

--- a/frontend/src/pages/landlord/tenants/LandlordTenants.tsx
+++ b/frontend/src/pages/landlord/tenants/LandlordTenants.tsx
@@ -1,27 +1,61 @@
 import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Icon } from '@iconify/react';
 import LandlordLayout from '../../../components/landlord/LandlordLayout';
+import LandlordManagerActionsPopover, {
+  type ManagerAction,
+} from '../../../components/landlord/LandlordManagerActionsPopover';
+import ReportManager from '../../../components/landlord/LandlordManagerReportController';
 import TenantsToolbar from '../../../components/landlord/tenants/TenantsToolbar';
 import TenantCard from '../../../components/landlord/tenants/TenantCard';
 import RemoveTenantPopup from '../../../components/landlord/tenants/popups/RemoveTenantPopup';
 import {
   defaultTenantListFilters,
   filterAndSortTenants,
+  filterTenantsByName,
   tenantFiltersActive,
 } from '../../../utils/tenantListFilters';
 import { pendingApplications, tenants, type Tenant } from '../../../data/landlordTenants';
 
 const LandlordTenants = () => {
+  const navigate = useNavigate();
   const pendingCount = pendingApplications.length;
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [reportTarget, setReportTarget] = useState<Tenant | null>(null);
   const [removeTarget, setRemoveTarget] = useState<Tenant | null>(null);
   const [filters, setFilters] = useState(defaultTenantListFilters);
+  const [nameSearchQuery, setNameSearchQuery] = useState('');
 
-  const filteredTenants = useMemo(() => filterAndSortTenants(tenants, filters), [filters]);
+  const handleTenantAction = (tenant: Tenant, action: ManagerAction) => {
+    setOpenMenuId(null);
+    if (action === 'message') {
+      navigate('/landlord/messages');
+      return;
+    }
+    if (action === 'report') {
+      setReportTarget(tenant);
+      return;
+    }
+    if (action === 'remove') {
+      setRemoveTarget(tenant);
+    }
+  };
+
+  const filteredTenants = useMemo(() => {
+    const sorted = filterAndSortTenants(tenants, filters);
+    return filterTenantsByName(sorted, nameSearchQuery);
+  }, [filters, nameSearchQuery]);
 
   const patchFilters = (patch: Partial<typeof filters>) => {
     setFilters((prev) => ({ ...prev, ...patch }));
   };
+
+  const resetAllListFilters = () => {
+    setFilters(defaultTenantListFilters);
+    setNameSearchQuery('');
+  };
+
+  const hasActiveListFilters = tenantFiltersActive(filters) || nameSearchQuery.trim().length > 0;
 
   return (
     <LandlordLayout activeSidebarItem="tenants" breadcrumbs={[{ label: 'My Tenants' }]}>
@@ -34,7 +68,9 @@ const LandlordTenants = () => {
             countClassName="text-[#096c5b]"
             filter={filters}
             onFilterChange={patchFilters}
-            onResetFilters={() => setFilters(defaultTenantListFilters)}
+            onResetFilters={resetAllListFilters}
+            nameSearchQuery={nameSearchQuery}
+            onNameSearchChange={setNameSearchQuery}
           />
           <div className="h-[2px] w-full rounded-[100px] bg-[#f0f0f0]" />
 
@@ -83,12 +119,12 @@ const LandlordTenants = () => {
               No tenants match your filters
             </p>
             <p className="font-['Inter',sans-serif] text-[14px] text-[#666]">
-              Try a different status, sort, or facility search.
+              Try a different status, sort, facility search, or tenant name search.
             </p>
-            {tenantFiltersActive(filters) && (
+            {hasActiveListFilters && (
               <button
                 type="button"
-                onClick={() => setFilters(defaultTenantListFilters)}
+                onClick={resetAllListFilters}
                 className="rounded-[12px] bg-[#cbf6ed] px-[24px] py-[10px] font-['Inter',sans-serif] text-[14px] font-semibold text-[#096c5b] transition-opacity hover:opacity-80"
               >
                 Reset filters
@@ -105,7 +141,16 @@ const LandlordTenants = () => {
                 key={tenant.id}
                 tenant={tenant}
                 to={`/landlord/tenants/${tenant.id}`}
-                onMoreOptions={setRemoveTarget}
+                menuOpen={openMenuId === tenant.id}
+                onKebabClick={(t) => setOpenMenuId((prev) => (prev === t.id ? null : t.id))}
+                actionMenu={
+                  <LandlordManagerActionsPopover
+                    open={openMenuId === tenant.id}
+                    onClose={() => setOpenMenuId(null)}
+                    onAction={(action) => handleTenantAction(tenant, action)}
+                    subjectName={tenant.displayName}
+                  />
+                }
               />
             ))}
           </section>
@@ -115,6 +160,13 @@ const LandlordTenants = () => {
         targetName={removeTarget?.displayName ?? null}
         isOpen={Boolean(removeTarget)}
         onClose={() => setRemoveTarget(null)}
+      />
+      <ReportManager
+        isOpen={Boolean(reportTarget)}
+        onClose={() => setReportTarget(null)}
+        manager={
+          reportTarget ? { displayName: reportTarget.displayName, email: reportTarget.email } : null
+        }
       />
     </LandlordLayout>
   );

--- a/frontend/src/pages/landlord/tenants/LandlordUnvalidatedTenantDetail.tsx
+++ b/frontend/src/pages/landlord/tenants/LandlordUnvalidatedTenantDetail.tsx
@@ -1,10 +1,13 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import LandlordLayout from '../../../components/landlord/LandlordLayout';
 import TenantAvatar from '../../../components/landlord/tenants/TenantAvatar';
 import TenantInfoField from '../../../components/landlord/tenants/TenantInfoField';
 import TenantProfileHeader from '../../../components/landlord/tenants/TenantProfileHeader';
-import SubmittedDocumentCard from '../../../components/landlord/tenants/SubmittedDocumentCard';
+import SubmittedDocumentCard, {
+  type DocumentReviewStatus,
+} from '../../../components/landlord/tenants/SubmittedDocumentCard';
+import ApproveDocumentPopup from '../../../components/landlord/tenants/popups/ApproveDocumentPopup';
 import FileActionPopup from '../../../components/landlord/tenants/popups/FileActionPopup';
 import RejectDocumentPopup from '../../../components/landlord/tenants/popups/RejectDocumentPopup';
 import { getPendingApplicationById, type SubmittedDocument } from '../../../data/landlordTenants';
@@ -15,20 +18,41 @@ const LandlordUnvalidatedTenantDetail = () => {
   const application = tenantId ? getPendingApplicationById(tenantId) : undefined;
   const [openFileMenuId, setOpenFileMenuId] = useState<string | null>(null);
   const [rejectTarget, setRejectTarget] = useState<SubmittedDocument | null>(null);
+  const [approveTarget, setApproveTarget] = useState<SubmittedDocument | null>(null);
+  const [docReview, setDocReview] = useState<Record<string, DocumentReviewStatus>>({});
+
+  useEffect(() => {
+    if (!application) return;
+    const next: Record<string, DocumentReviewStatus> = {};
+    application.documents.forEach((d) => {
+      next[d.id] = 'pending';
+    });
+    setDocReview(next);
+    setOpenFileMenuId(null);
+    setRejectTarget(null);
+    setApproveTarget(null);
+  }, [application]);
+
+  const hasDocuments = Boolean(application && application.documents.length > 0);
+
+  const allDocumentsApproved = useMemo(() => {
+    if (!application) return true;
+    if (application.documents.length === 0) return true;
+    return application.documents.every((d) => docReview[d.id] === 'approved');
+  }, [application, docReview]);
+
+  const handleRejectApplication = () => {
+    navigate('/landlord/tenants/unvalidated');
+  };
+
+  const handleApproveApplication = () => {
+    if (!allDocumentsApproved) return;
+    navigate('/landlord/tenants');
+  };
 
   if (!application) {
     return <Navigate to="/landlord/tenants/unvalidated" replace />;
   }
-
-  const hasDocuments = application.documents.length > 0;
-
-  const handleReject = () => {
-    navigate('/landlord/tenants/unvalidated');
-  };
-
-  const handleApprove = () => {
-    navigate('/landlord/tenants');
-  };
 
   return (
     <LandlordLayout
@@ -99,15 +123,16 @@ const LandlordUnvalidatedTenantDetail = () => {
                     <SubmittedDocumentCard
                       key={document.id}
                       document={document}
-                      onMoreOptions={() =>
-                        setOpenFileMenuId((prev) => (prev === document.id ? null : document.id))
+                      reviewStatus={docReview[document.id] ?? 'pending'}
+                      onMoreOptions={(doc) =>
+                        setOpenFileMenuId((prev) => (prev === doc.id ? null : doc.id))
                       }
                       actionMenu={
                         <FileActionPopup
                           isOpen={openFileMenuId === document.id}
                           onApprove={() => {
                             setOpenFileMenuId(null);
-                            handleApprove();
+                            setApproveTarget(document);
                           }}
                           onReject={() => {
                             setOpenFileMenuId(null);
@@ -119,23 +144,37 @@ const LandlordUnvalidatedTenantDetail = () => {
                   ))}
                 </div>
 
-                <div className="flex w-full items-center justify-center gap-[10px] px-[12px] pt-[8px]">
-                  <button
-                    type="button"
-                    onClick={handleReject}
-                    className="flex cursor-pointer items-center justify-center rounded-[16px] bg-[#f1f5f9] px-[16px] py-[12px] font-['Inter',sans-serif] text-[14px] font-bold transition-colors duration-200 hover:bg-[#e5edf4]"
-                  >
-                    <span className="bg-linear-to-b from-[#c00f0f] to-[#e44f4f] bg-clip-text text-transparent">
-                      Reject
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleApprove}
-                    className="flex cursor-pointer items-center justify-center rounded-[16px] bg-[#cbf6ed] px-[24px] py-[12px] font-['Inter',sans-serif] text-[14px] font-bold text-[#096c5b] transition-colors duration-200 hover:bg-[#b4efe1]"
-                  >
-                    Approve
-                  </button>
+                {!allDocumentsApproved && (
+                  <p className="px-[12px] text-center font-['Inter',sans-serif] text-[13px] font-medium text-[#64748b]">
+                    Every document must be approved before you can accept this applicant.
+                  </p>
+                )}
+
+                <div className="flex w-full flex-col items-center justify-center gap-[10px] px-[12px] pt-[8px]">
+                  <div className="flex items-center justify-center gap-[10px]">
+                    <button
+                      type="button"
+                      onClick={handleRejectApplication}
+                      className="flex cursor-pointer items-center justify-center rounded-[16px] bg-[#f1f5f9] px-[16px] py-[12px] font-['Inter',sans-serif] text-[14px] font-bold transition-colors duration-200 hover:bg-[#e5edf4]"
+                    >
+                      <span className="bg-linear-to-b from-[#c00f0f] to-[#e44f4f] bg-clip-text text-transparent">
+                        Reject
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleApproveApplication}
+                      disabled={!allDocumentsApproved}
+                      className={[
+                        "flex cursor-pointer items-center justify-center rounded-[16px] px-[24px] py-[12px] font-['Inter',sans-serif] text-[14px] font-bold transition-colors duration-200",
+                        allDocumentsApproved
+                          ? 'bg-[#cbf6ed] text-[#096c5b] hover:bg-[#b4efe1]'
+                          : 'cursor-not-allowed bg-[#e8ecf1] text-[#94a3b8]',
+                      ].join(' ')}
+                    >
+                      Approve
+                    </button>
+                  </div>
                 </div>
               </>
             )}
@@ -143,11 +182,26 @@ const LandlordUnvalidatedTenantDetail = () => {
         </div>
       </div>
 
+      <ApproveDocumentPopup
+        document={approveTarget}
+        isOpen={Boolean(approveTarget)}
+        onClose={() => setApproveTarget(null)}
+        onConfirm={() => {
+          if (approveTarget) {
+            setDocReview((prev) => ({ ...prev, [approveTarget.id]: 'approved' }));
+          }
+        }}
+      />
+
       <RejectDocumentPopup
         document={rejectTarget}
         isOpen={Boolean(rejectTarget)}
         onClose={() => setRejectTarget(null)}
-        onConfirm={() => navigate('/landlord/tenants/unvalidated')}
+        onConfirm={() => {
+          if (rejectTarget) {
+            setDocReview((prev) => ({ ...prev, [rejectTarget.id]: 'rejected' }));
+          }
+        }}
       />
     </LandlordLayout>
   );

--- a/frontend/src/utils/tenantListFilters.ts
+++ b/frontend/src/utils/tenantListFilters.ts
@@ -63,6 +63,15 @@ export function filterAndSortTenants(list: Tenant[], filters: TenantListFilters)
   return out;
 }
 
+export function filterTenantsByName(list: Tenant[], nameQuery: string): Tenant[] {
+  const q = nameQuery.trim().toLowerCase();
+  if (!q) return list;
+  return list.filter((t) => {
+    const hay = `${t.displayName} ${t.fullName}`.toLowerCase();
+    return hay.includes(q);
+  });
+}
+
 export function tenantFiltersActive(filters: TenantListFilters): boolean {
   return filters.status !== 'all' || filters.facilityQuery.trim().length > 0;
 }

--- a/frontend/src/utils/tenantListFilters.ts
+++ b/frontend/src/utils/tenantListFilters.ts
@@ -1,0 +1,68 @@
+import type { PaymentStatus, Tenant } from '../data/landlordTenants';
+
+export type TenantListFilters = {
+  status: 'all' | PaymentStatus;
+  sort: 'date-asc' | 'date-desc' | 'amount-asc' | 'amount-desc';
+  facilityQuery: string;
+};
+
+export const defaultTenantListFilters: TenantListFilters = {
+  status: 'all',
+  sort: 'date-desc',
+  facilityQuery: '',
+};
+
+/** Parse first segment of `contractDuration` e.g. `04/26 - 4/27` → contract start (month). */
+export function getContractStartTimestamp(tenant: Tenant): number {
+  const first = tenant.contractDuration.split('-')[0]?.trim() ?? '';
+  const [mm, yy] = first.split('/').map((x) => parseInt(x.trim(), 10));
+  if (!Number.isFinite(mm) || !Number.isFinite(yy)) return 0;
+  const year = yy < 100 ? 2000 + yy : yy;
+  return new Date(year, mm - 1, 1).getTime();
+}
+
+export function parseBaseRentAmount(baseRentFee: string): number {
+  const n = parseFloat(baseRentFee.replace(/,/g, ''));
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function filterAndSortTenants(list: Tenant[], filters: TenantListFilters): Tenant[] {
+  const q = filters.facilityQuery.trim().toLowerCase();
+
+  let out = list.filter((t) => {
+    if (filters.status !== 'all' && t.billingStatus !== filters.status) return false;
+    if (q) {
+      const hay = `${t.dormName} ${t.unit}`.toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    return true;
+  });
+
+  const byDate = (a: Tenant, b: Tenant) =>
+    getContractStartTimestamp(a) - getContractStartTimestamp(b);
+  const byAmount = (a: Tenant, b: Tenant) =>
+    parseBaseRentAmount(a.baseRentFee) - parseBaseRentAmount(b.baseRentFee);
+
+  switch (filters.sort) {
+    case 'date-asc':
+      out = [...out].sort(byDate);
+      break;
+    case 'date-desc':
+      out = [...out].sort((a, b) => byDate(b, a));
+      break;
+    case 'amount-asc':
+      out = [...out].sort(byAmount);
+      break;
+    case 'amount-desc':
+      out = [...out].sort((a, b) => byAmount(b, a));
+      break;
+    default:
+      break;
+  }
+
+  return out;
+}
+
+export function tenantFiltersActive(filters: TenantListFilters): boolean {
+  return filters.status !== 'all' || filters.facilityQuery.trim().length > 0;
+}


### PR DESCRIPTION
### Changes
- Tenant list: Search by tenant name. Facility filters in the panel are unchanged.
- Tenant cards: ⋮ menu → Message (messages page), Report (same flow as managers), Remove (existing remove popup).
- Tenant detail (validated): Documents are view-only; no ⋮ on each file.
- Application detail (unvalidated): Approve or reject each document with modals; Approve applicant only works after every document is approved.
- Popover: Renamed label prop to subjectName so managers and tenants share the same menu component.