### PR TITLE
feat: admin calendar backend integration

### DIFF
--- a/backend/src/features/availability/availability.controller.ts
+++ b/backend/src/features/availability/availability.controller.ts
@@ -1,0 +1,24 @@
+import type { RequestHandler } from 'express';
+import { getLandlordAvailability, updateLandlordAvailability } from './availability.service.js';
+import assert from 'node:assert';
+import { AppError } from '../../error.js';
+
+export const routeGetMyAvailability: RequestHandler = async (req, res) => {
+  assert.ok(req.user);
+  const landlordId = req.user._id;
+  const availability = await getLandlordAvailability(landlordId);
+  res.status(200).json({ data: availability });
+};
+
+export const routeUpdateMyAvailability: RequestHandler = async (req, res) => {
+  assert.ok(req.user);
+  const landlordId = req.user._id;
+  const { grid } = req.body;
+
+  if (!grid || !Array.isArray(grid)) {
+    throw new AppError(400, 'Invalid availability grid.');
+  }
+
+  const updated = await updateLandlordAvailability(landlordId, grid);
+  res.status(200).json({ data: updated });
+};

--- a/backend/src/features/availability/availability.model.ts
+++ b/backend/src/features/availability/availability.model.ts
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+
+export type AvailabilityType = {
+  landlordId: mongoose.Types.ObjectId;
+  // 10x7 grid representing 8 AM to 5 PM (10 hours) for 7 days
+  // grid[hourIndex][dayIndex] where hourIndex 0 is 8 AM and dayIndex 0 is Sunday
+  grid: boolean[][];
+};
+
+const availabilitySchema = new mongoose.Schema<AvailabilityType>(
+  {
+    landlordId: { type: mongoose.Schema.Types.ObjectId, ref: 'Landlord', required: true, unique: true },
+    grid: {
+      type: [[Boolean]],
+      default: () => Array.from({ length: 10 }, () => Array(7).fill(false)),
+    },
+  },
+  { 
+    timestamps: true,
+    collection: 'visitavailabilities' // Explicitly set as requested
+  },
+);
+
+export const VisitAvailability = mongoose.model('VisitAvailability', availabilitySchema);

--- a/backend/src/features/availability/availability.model.ts
+++ b/backend/src/features/availability/availability.model.ts
@@ -2,8 +2,6 @@ import mongoose from 'mongoose';
 
 export type AvailabilityType = {
   landlordId: mongoose.Types.ObjectId;
-  // 10x7 grid representing 8 AM to 5 PM (10 hours) for 7 days
-  // grid[hourIndex][dayIndex] where hourIndex 0 is 8 AM and dayIndex 0 is Sunday
   grid: boolean[][];
 };
 
@@ -15,9 +13,9 @@ const availabilitySchema = new mongoose.Schema<AvailabilityType>(
       default: () => Array.from({ length: 10 }, () => Array(7).fill(false)),
     },
   },
-  { 
+  {
     timestamps: true,
-    collection: 'visitavailabilities' // Explicitly set as requested
+    collection: 'visitavailabilities'
   },
 );
 

--- a/backend/src/features/availability/availability.router.ts
+++ b/backend/src/features/availability/availability.router.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { routeGetMyAvailability, routeUpdateMyAvailability } from './availability.controller.js';
+import { isLandlord } from '../../middleware.js';
+
+const router = Router();
+
+router.get('/me', isLandlord, routeGetMyAvailability);
+router.patch('/me', isLandlord, routeUpdateMyAvailability);
+
+export default router;

--- a/backend/src/features/availability/availability.service.ts
+++ b/backend/src/features/availability/availability.service.ts
@@ -3,15 +3,14 @@ import { VisitAvailability } from './availability.model.js';
 
 export const getLandlordAvailability = async (landlordId: mongoose.Types.ObjectId) => {
   let availability = await VisitAvailability.findOne({ landlordId });
-  
+
   if (!availability) {
-    // Return default empty grid if none exists yet
     availability = new VisitAvailability({
       landlordId,
       grid: Array.from({ length: 10 }, () => Array(7).fill(false)),
     });
   }
-  
+
   return availability;
 };
 

--- a/backend/src/features/availability/availability.service.ts
+++ b/backend/src/features/availability/availability.service.ts
@@ -1,0 +1,27 @@
+import type mongoose from 'mongoose';
+import { VisitAvailability } from './availability.model.js';
+
+export const getLandlordAvailability = async (landlordId: mongoose.Types.ObjectId) => {
+  let availability = await VisitAvailability.findOne({ landlordId });
+  
+  if (!availability) {
+    // Return default empty grid if none exists yet
+    availability = new VisitAvailability({
+      landlordId,
+      grid: Array.from({ length: 10 }, () => Array(7).fill(false)),
+    });
+  }
+  
+  return availability;
+};
+
+export const updateLandlordAvailability = async (
+  landlordId: mongoose.Types.ObjectId,
+  grid: boolean[][],
+) => {
+  return await VisitAvailability.findOneAndUpdate(
+    { landlordId },
+    { grid },
+    { upsert: true, new: true },
+  );
+};

--- a/backend/src/features/booking/booking.model.ts
+++ b/backend/src/features/booking/booking.model.ts
@@ -12,7 +12,7 @@ export type BookingType = {
 
 const visitBookingSchema = new mongoose.Schema<BookingType>(
   {
-    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'Student', required: true },
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
     facilityId: { type: mongoose.Schema.Types.ObjectId, ref: 'HousingFacility', required: true },
     status: { type: String, enum: BOOKING_STATUS, default: 'pending' },
     endDate: { type: Date, required: true },

--- a/backend/src/features/booking/booking.router.ts
+++ b/backend/src/features/booking/booking.router.ts
@@ -9,7 +9,8 @@ import {
 import {
   isSuperAdmin,
   isVerifiedStudent,
-  manageListingsFilter,
+  isLoggedIn,
+  manageBookingsFilter,
   selfFilter,
 } from '../../middleware.js';
 
@@ -18,7 +19,7 @@ const router = Router();
 // ============================================================================
 // GET /api/bookings
 // ============================================================================
-router.get('/', isSuperAdmin, routeGetBookings);
+router.get('/', isLoggedIn, manageBookingsFilter, routeGetBookings);
 
 // ============================================================================
 // GET /api/bookings/facilities/:facilityId/available-slots
@@ -37,7 +38,7 @@ router.post('/', isVerifiedStudent, routeCreateBooking);
 // ============================================================================
 // PATCH /api/bookings/:bookingId
 // ============================================================================
-router.patch('/:bookingId', manageListingsFilter, routeUpdateBookingStatus);
+router.patch('/:bookingId', isLoggedIn, manageBookingsFilter, routeUpdateBookingStatus);
 
 // ============================================================================
 // DELETE /api/bookings/:bookingId

--- a/backend/src/features/booking/booking.router.ts
+++ b/backend/src/features/booking/booking.router.ts
@@ -19,7 +19,7 @@ const router = Router();
 // ============================================================================
 // GET /api/bookings
 // ============================================================================
-router.get('/', isLoggedIn, manageBookingsFilter, routeGetBookings);
+router.get('/', isLoggedIn, (req, res, next) => { console.log('ROUTER: User Type:', req.user?.userType); next(); }, manageBookingsFilter, (req, res, next) => { console.log('ROUTER: Passed manageBookingsFilter'); next(); }, routeGetBookings);
 
 // ============================================================================
 // GET /api/bookings/facilities/:facilityId/available-slots

--- a/backend/src/features/booking/booking.service.ts
+++ b/backend/src/features/booking/booking.service.ts
@@ -146,10 +146,7 @@ export const getBookings = async (
   query: Partial<GetBookingArguments>,
   filters: QueryFilter<BookingType>,
 ) => {
-  return await VisitBooking.where(filters)
-    .find(buildQuery<BookingType>(query))
-    .populate('userId', 'firstName lastName')
-    .populate('facilityId', 'name');
+  return await VisitBooking.where(filters).find(buildQuery<BookingType>(query));
 };
 
 export const updateBookingStatus = async (

--- a/backend/src/features/booking/booking.service.ts
+++ b/backend/src/features/booking/booking.service.ts
@@ -158,10 +158,7 @@ export const updateBookingStatus = async (
   filters: QueryFilter<BookingType>,
 ) => {
   const booking = await VisitBooking.findOne(combineFilters(filters, { _id: bookingId }));
-
-  if (!booking) {
-    throw new AppError(404, 'Booking not found.');
-  }
+  if (!booking) throw new AppError(404, 'Booking not found.');
 
   if (booking.status !== 'pending') {
     throw new AppError(400, 'Booking has already been processed.');

--- a/backend/src/features/booking/booking.service.ts
+++ b/backend/src/features/booking/booking.service.ts
@@ -4,6 +4,7 @@ import { AppError } from '../../error.js';
 import { combineFilters } from '../../middleware.js';
 import { HousingFacility, type HousingFacilityType } from '../facility/facility.model.js';
 import { type BookingType, VisitBooking } from './booking.model.js';
+import { VisitAvailability } from '../availability/availability.model.js';
 import { buildQuery } from '../../utils.js';
 import type { BookingStatusType } from 'shared';
 
@@ -35,8 +36,8 @@ export type GetBookingArguments = {
   message: string;
 };
 
-const DEFAULT_VISIT_START_HOUR = 9;
-const DEFAULT_VISIT_END_HOUR = 17;
+const DEFAULT_VISIT_START_HOUR = 8;
+const DEFAULT_VISIT_END_HOUR = 18;
 const VISIT_SLOT_MINUTES = 60;
 
 const isSameSlot = (left: Date, right: Date) => left.getTime() === right.getTime();
@@ -50,18 +51,24 @@ const getDayBounds = (date: Date) => {
   return { dayStart, dayEnd };
 };
 
-const getDefaultVisitStarts = (date: Date) => {
+const getAvailableTimesFromGrid = (grid: boolean[][], date: Date) => {
   const { dayStart } = getDayBounds(date);
-  const dayOfWeek = dayStart.getDay();
+  const dayOfWeek = dayStart.getDay(); // 0-6
 
-  // TODO: Replace these default hours with persisted landlord/manager availability.
-  return dayOfWeek === 0 || dayOfWeek === 6
-    ? []
-    : Array.from({ length: DEFAULT_VISIT_END_HOUR - DEFAULT_VISIT_START_HOUR }, (_, index) => {
+  const availableSlots: Date[] = [];
+  for (let hourIdx = 0; hourIdx < 10; hourIdx++) {
+    if (grid[hourIdx][dayOfWeek]) {
       const start = new Date(dayStart);
-      start.setHours(DEFAULT_VISIT_START_HOUR + index, 0, 0, 0);
-      return start;
-    });
+      start.setHours(DEFAULT_VISIT_START_HOUR + hourIdx, 0, 0, 0);
+      availableSlots.push(start);
+    }
+  }
+  return availableSlots;
+};
+
+const getDefaultAvailabilityGrid = () => {
+  const grid = Array.from({ length: 10 }, () => Array(7).fill(false));
+  return grid;
 };
 
 export const getAvailableVisitSlots = async (
@@ -74,7 +81,9 @@ export const getAvailableVisitSlots = async (
   if (!facility.allowVisit) return [];
 
   const { dayStart, dayEnd } = getDayBounds(date);
-  const availableStarts = getDefaultVisitStarts(date).filter((start) => start > new Date());
+  const availability = await VisitAvailability.findOne({ landlordId: facility.landlordId });
+  const grid = availability?.grid ?? getDefaultAvailabilityGrid();
+  const availableStarts = getAvailableTimesFromGrid(grid, date).filter((start) => start > new Date());
 
   const bookedSlots = await VisitBooking.find({
     facilityId,
@@ -109,7 +118,9 @@ export const createBooking = async (
   if (!facility) throw new AppError(404, 'Facility not found.');
   if (!facility.allowVisit) throw new AppError(422, 'This facility is not accepting visits.');
 
-  const selectedSlotStart = getDefaultVisitStarts(data.startDate).find((slotStart) =>
+  const availability = await VisitAvailability.findOne({ landlordId: facility.landlordId });
+  const grid = availability?.grid ?? getDefaultAvailabilityGrid();
+  const selectedSlotStart = getAvailableTimesFromGrid(grid, data.startDate).find((slotStart) =>
     isSameSlot(slotStart, data.startDate),
   );
   if (!selectedSlotStart) {

--- a/backend/src/features/booking/booking.service.ts
+++ b/backend/src/features/booking/booking.service.ts
@@ -5,6 +5,7 @@ import { combineFilters } from '../../middleware.js';
 import { HousingFacility, type HousingFacilityType } from '../facility/facility.model.js';
 import { type BookingType, VisitBooking } from './booking.model.js';
 import { VisitAvailability } from '../availability/availability.model.js';
+import { User } from '../user/user.model.js';
 import { buildQuery } from '../../utils.js';
 import type { BookingStatusType } from 'shared';
 
@@ -145,7 +146,10 @@ export const getBookings = async (
   query: Partial<GetBookingArguments>,
   filters: QueryFilter<BookingType>,
 ) => {
-  return await VisitBooking.where(filters).find(buildQuery<BookingType>(query));
+  return await VisitBooking.where(filters)
+    .find(buildQuery<BookingType>(query))
+    .populate('userId', 'firstName lastName')
+    .populate('facilityId', 'name');
 };
 
 export const updateBookingStatus = async (
@@ -154,7 +158,10 @@ export const updateBookingStatus = async (
   filters: QueryFilter<BookingType>,
 ) => {
   const booking = await VisitBooking.findOne(combineFilters(filters, { _id: bookingId }));
-  if (!booking) throw new AppError(404, 'Booking not found.');
+
+  if (!booking) {
+    throw new AppError(404, 'Booking not found.');
+  }
 
   if (booking.status !== 'pending') {
     throw new AppError(400, 'Booking has already been processed.');

--- a/backend/src/features/booking/booking.service.ts
+++ b/backend/src/features/booking/booking.service.ts
@@ -58,10 +58,10 @@ const getDefaultVisitStarts = (date: Date) => {
   return dayOfWeek === 0 || dayOfWeek === 6
     ? []
     : Array.from({ length: DEFAULT_VISIT_END_HOUR - DEFAULT_VISIT_START_HOUR }, (_, index) => {
-        const start = new Date(dayStart);
-        start.setHours(DEFAULT_VISIT_START_HOUR + index, 0, 0, 0);
-        return start;
-      });
+      const start = new Date(dayStart);
+      start.setHours(DEFAULT_VISIT_START_HOUR + index, 0, 0, 0);
+      return start;
+    });
 };
 
 export const getAvailableVisitSlots = async (

--- a/backend/src/features/booking/booking.service.ts
+++ b/backend/src/features/booking/booking.service.ts
@@ -146,7 +146,10 @@ export const getBookings = async (
   query: Partial<GetBookingArguments>,
   filters: QueryFilter<BookingType>,
 ) => {
-  return await VisitBooking.where(filters).find(buildQuery<BookingType>(query));
+  return await VisitBooking.where(filters)
+    .find(buildQuery<BookingType>(query))
+    .populate('userId', 'firstName lastName')
+    .populate('facilityId', 'name');
 };
 
 export const updateBookingStatus = async (

--- a/backend/src/features/calendar/calendar.service.ts
+++ b/backend/src/features/calendar/calendar.service.ts
@@ -27,6 +27,7 @@ export const getCalendar = async (
   if (userType === 'Student') {
     const bookings = await VisitBooking.find({
       userId: userId,
+      status: 'accepted',
       startDate: { $lte: endDate },
       endDate: { $gte: startDate },
     });
@@ -125,6 +126,7 @@ export const getCalendar = async (
     if (facilityIds.length > 0) {
       const bookings = await VisitBooking.find({
         facilityId: { $in: facilityIds },
+        status: 'accepted',
         startDate: { $lte: endDate },
         endDate: { $gte: startDate },
       });

--- a/backend/src/middleware.ts
+++ b/backend/src/middleware.ts
@@ -106,11 +106,15 @@ const facilityManagerFilter =
     const facilityFilter: QueryFilter<HousingFacilityType> =
       req.user.userType === 'Landlord'
         ? {
-            $or: [{ landlordId: req.user._id }, { managers: { $elemMatch: managerCriteria } }],
+            $or: [
+              { landlordId: req.user._id },
+              { managers: { $elemMatch: managerCriteria } },
+            ],
           }
         : { managers: { $elemMatch: managerCriteria } };
 
-    const facilityIds = await HousingFacility.find(facilityFilter).distinct('_id');
+    const facilities = await HousingFacility.find(facilityFilter);
+    const facilityIds = facilities.map((f) => f._id);
 
     res.locals.filters = {
       facilityId: { $in: facilityIds },

--- a/backend/src/middleware.ts
+++ b/backend/src/middleware.ts
@@ -58,29 +58,29 @@ type ManagerEntry = {
 
 export const directManagerFilter =
   (permission: ManagerPermission | null): RequestHandler =>
-  async (req, res, next) => {
-    if (!req.user) throw new AppError(401, 'Unauthenticated');
+    async (req, res, next) => {
+      if (!req.user) throw new AppError(401, 'Unauthenticated');
 
-    const userId = req.user._id;
+      const userId = req.user._id;
 
-    let newFilter: QueryFilter<{ managers: ManagerEntry[] }>;
-    if (permission) {
-      const innerFilter: QueryFilter<ManagerEntry> = { userId };
-      innerFilter[`permissions.${permission}`] = true;
-      newFilter = {
-        managers: {
-          $elemMatch: innerFilter,
-        },
-      };
-    } else {
-      newFilter = {
-        'managers.userId': userId,
-      };
-    }
+      let newFilter: QueryFilter<{ managers: ManagerEntry[] }>;
+      if (permission) {
+        const innerFilter: QueryFilter<ManagerEntry> = { userId };
+        innerFilter[`permissions.${permission}`] = true;
+        newFilter = {
+          managers: {
+            $elemMatch: innerFilter,
+          },
+        };
+      } else {
+        newFilter = {
+          'managers.userId': userId,
+        };
+      }
 
-    res.locals.filters = combineFilters(res.locals.filters, newFilter);
-    next();
-  };
+      res.locals.filters = combineFilters(res.locals.filters, newFilter);
+      next();
+    };
 
 // Used when the object has a `facilityId`.
 //
@@ -90,37 +90,43 @@ export const directManagerFilter =
 // be able to pass.
 const facilityManagerFilter =
   (permission: ManagerPermission | null): RequestHandler =>
-  async (req, res, next) => {
-    assert.ok(req.user);
-    if (req.user.userType !== 'Manager' && req.user.userType !== 'Landlord')
-      throw new AppError(403, 'Forbidden.');
+    async (req, res, next) => {
+      assert.ok(req.user);
+      if (req.user.userType !== 'Manager' && req.user.userType !== 'Landlord')
+        throw new AppError(403, 'Forbidden.');
 
-    const managerCriteria: QueryFilter<{
-      userId: mongoose.Types.ObjectId;
-      permissions: ManagerPermissionType;
-    }> = { userId: req.user._id };
-    if (permission) {
-      managerCriteria[`permissions.${permission}`] = true;
-    }
+      const managerCriteria: QueryFilter<{
+        userId: mongoose.Types.ObjectId;
+        permissions: ManagerPermissionType;
+      }> = { userId: req.user._id };
+      if (permission) {
+        managerCriteria[`permissions.${permission}`] = true;
+      }
 
-    const facilityFilter: QueryFilter<HousingFacilityType> =
-      req.user.userType === 'Landlord'
-        ? {
+      const facilityFilter: QueryFilter<HousingFacilityType> =
+        req.user.userType === 'Landlord'
+          ? {
             $or: [
               { landlordId: req.user._id },
               { managers: { $elemMatch: managerCriteria } },
             ],
           }
-        : { managers: { $elemMatch: managerCriteria } };
+          : { managers: { $elemMatch: managerCriteria } };
 
-    const facilities = await HousingFacility.find(facilityFilter);
-    const facilityIds = facilities.map((f) => f._id);
+      const facilities = await HousingFacility.find(facilityFilter);
+      const facilityIds = facilities.map(f => f._id);
 
-    res.locals.filters = {
-      facilityId: { $in: facilityIds },
+      if (facilityIds.length === 0) {
+        console.warn(`SECURITY: User ${req.user._id} (${req.user.userType}) found 0 facilities for permission ${permission}`);
+      } else {
+        console.log(`SECURITY: User ${req.user._id} found ${facilityIds.length} facilities.`);
+      }
+
+      res.locals.filters = {
+        facilityId: { $in: facilityIds },
+      };
+      next();
     };
-    next();
-  };
 
 export const deleteListingsFilter = facilityManagerFilter('deleteListings');
 export const manageListingsFilter = facilityManagerFilter('manageListings');

--- a/backend/src/router.ts
+++ b/backend/src/router.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 
 import activityRouter from './features/activity/activity.router.js';
+import availabilityRouter from './features/availability/availability.router.js';
 import applicationRouter from './features/application/application.router.js';
 import authRouter from './features/auth/auth.router.js';
 import billingRouter from './features/billing/billing.router.js';
@@ -27,6 +28,7 @@ import { errorHandler } from './error.js';
 const router = Router();
 
 router.use('/activities', activityRouter);
+router.use('/availability', availabilityRouter);
 router.use('/applications', applicationRouter);
 router.use('/billings', billingRouter);
 router.use('/bookings', bookingRouter);

--- a/frontend/src/components/landlord/VisitsSections/LandlordDayEventsPopout.tsx
+++ b/frontend/src/components/landlord/VisitsSections/LandlordDayEventsPopout.tsx
@@ -7,6 +7,7 @@ export type VisitSlot = {
   visitorName: string;
   backgroundColor?: string;
   dayOfWeek: number;
+  startDate: Date;
 };
 
 export type LandlordDayEventsPopoutType = {

--- a/frontend/src/components/landlord/VisitsSections/LandlordEventPopout.tsx
+++ b/frontend/src/components/landlord/VisitsSections/LandlordEventPopout.tsx
@@ -7,6 +7,7 @@ export type VisitSlot = {
   visitorName: string;
   backgroundColor?: string;
   dayOfWeek: number;
+  startDate: Date;
 };
 
 export type LandlordEventPopoutType = {
@@ -35,9 +36,13 @@ const LandlordEventPopout: FunctionComponent<LandlordEventPopoutType> = ({
           <Icon icon="ic:round-person" className="w-12 h-12 text-teal shrink-0 mt-1" />
           <div className="flex-1">
             <div className="text-lg font-semibold text-dimgray mb-2">{event.visitorName}</div>
-            <div className="text-sm text-gray mb-4">Visit Time: {event.time}</div>
-            <div className="text-xs text-dimgray">
-              <span className="font-semibold">Visit ID:</span> {event.id}
+            <div className="text-sm text-gray">Visit Time: {event.time}</div>
+            <div className="text-sm text-gray">
+              Visit Date: {event.startDate.toLocaleDateString('en-US', {
+                month: 'long',
+                day: 'numeric',
+                year: 'numeric',
+              })}
             </div>
           </div>
         </div>

--- a/frontend/src/components/landlord/VisitsSections/SetAvailableTime.tsx
+++ b/frontend/src/components/landlord/VisitsSections/SetAvailableTime.tsx
@@ -1,4 +1,5 @@
-import { type FunctionComponent, useState, useCallback } from 'react';
+import { type FunctionComponent, useState, useCallback, useEffect } from 'react';
+import { api } from '../../../service/axiosInstance';
 
 const HOURS = Array.from({ length: 10 }, (_, i) => `${i + 8}:00`);
 const DAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
@@ -9,15 +10,25 @@ interface SetAvailableTimeProps {
 
 const SetAvailableTime: FunctionComponent<SetAvailableTimeProps> = ({ onClose }) => {
   const [availability, setAvailability] = useState<boolean[][]>(
-    Array(10)
-      .fill(null)
-      .map(() => Array(7).fill(true)),
+    Array.from({ length: 10 }, () => Array(7).fill(false)),
   );
-  const [initialAvailability] = useState<boolean[][]>(
-    Array(10)
-      .fill(null)
-      .map(() => Array(7).fill(true)),
-  );
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchAvailability = async () => {
+      try {
+        const response = await api.get('/api/availability/me');
+        if (response.data?.data?.grid) {
+          setAvailability(response.data.data.grid);
+        }
+      } catch (error) {
+        console.error('Failed to fetch availability:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchAvailability();
+  }, []);
 
   const handleTileClick = useCallback((row: number, col: number) => {
     setAvailability((prev) => {
@@ -28,14 +39,17 @@ const SetAvailableTime: FunctionComponent<SetAvailableTimeProps> = ({ onClose })
   }, []);
 
   const handleCancel = useCallback(() => {
-    setAvailability(initialAvailability.map((row) => [...row]));
     onClose?.();
-  }, [initialAvailability, onClose]);
+  }, [onClose]);
 
-  const handleSave = useCallback(() => {
-    console.log('Saved availability:', availability);
-    // TODO: Call API to save availability
-    onClose?.();
+  const handleSave = useCallback(async () => {
+    try {
+      await api.patch('/api/availability/me', { grid: availability });
+      onClose?.();
+    } catch (error) {
+      console.error('Failed to save availability:', error);
+      alert('Failed to save availability. Please try again.');
+    }
   }, [availability, onClose]);
   return (
     <div className="relative rounded-2xl bg-white dark:bg-[#141515] w-[900px] overflow-hidden flex flex-col items-start py-8 px-12 box-border gap-2.5 text-center text-[24px] text-teal dark:text-[#72cbb8] font-inter">

--- a/frontend/src/components/landlord/VisitsSections/VisitRequestsSection.tsx
+++ b/frontend/src/components/landlord/VisitsSections/VisitRequestsSection.tsx
@@ -60,6 +60,7 @@ export default function VisitRequestsSection({
           requests.map((request) => (
             <VisitRequestCard
               key={request.id}
+              id={request.id}
               visitorName={request.visitorName}
               dateTime={request.dateTime}
               propertyName={request.propertyName}

--- a/frontend/src/components/user/user-calendar/CalendarPopout.tsx
+++ b/frontend/src/components/user/user-calendar/CalendarPopout.tsx
@@ -210,7 +210,6 @@ const CalendarPopout: FunctionComponent<CalendarPopoutType> = ({
         endDate: selectedSlot.endDate as unknown as Date,
         message: message.trim() || undefined,
       });
-      setSuccess('Visit booked. You can now see it in My Calendar.');
       onBooked?.();
       setTimeout(onClose, 900);
     } catch (err) {

--- a/frontend/src/pages/landlord/visits/LandlordVisits.tsx
+++ b/frontend/src/pages/landlord/visits/LandlordVisits.tsx
@@ -1,5 +1,6 @@
 import type { FunctionComponent } from 'react';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { api } from '../../../service/axiosInstance';
 import { Icon } from '@iconify/react';
 import LandlordLayout, { type BreadcrumbItem } from '../../../components/landlord/LandlordLayout';
 import SetAvailableTime from '../../../components/landlord/VisitsSections/SetAvailableTime';
@@ -51,8 +52,35 @@ const Visits: FunctionComponent = () => {
     'Dec',
   ];
 
-  // Fetch visit data from API (currently empty, waiting for backend integration)
-  const allVisits: VisitSlot[] = [];
+  const [allVisits, setAllVisits] = useState<VisitSlot[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchVisits = useCallback(async () => {
+    try {
+      const response = await api.get('/api/bookings');
+      if (response.data?.data) {
+        // Map backend bookings to VisitSlot interface
+        const mapped: VisitSlot[] = response.data.data.map((b: any) => ({
+          id: b._id,
+          visitorName: b.userId?.firstName ? `${b.userId.firstName} ${b.userId.lastName}` : 'Student',
+          time: new Date(b.startDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+          status: b.status,
+          dayOfWeek: new Date(b.startDate).getDay(),
+          startDate: new Date(b.startDate),
+          backgroundColor: b.status === 'accepted' ? 'bg-blue-100 dark:bg-[#12342e]' : 'bg-orange-100 dark:bg-[#342e12]',
+        }));
+        setAllVisits(mapped);
+      }
+    } catch (error) {
+      console.error('Failed to fetch visits:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchVisits();
+  }, [fetchVisits]);
 
   const month = currentDate.getMonth();
   const year = currentDate.getFullYear();
@@ -124,11 +152,22 @@ const Visits: FunctionComponent = () => {
   };
 
   // Transform visits to show all upcoming visits
-  const upcomingVisits = allVisits.map((visit, index) => ({
-    id: visit.id,
-    propertyName: visit.visitorName,
-    visitCount: 1,
-  }));
+  const upcomingVisits = allVisits
+    .filter((v) => v.status === 'accepted')
+    .map((visit) => ({
+      id: visit.id,
+      propertyName: visit.visitorName,
+      visitCount: 1,
+    }));
+
+  const pendingRequests = allVisits
+    .filter((v) => v.status === 'pending')
+    .map((v) => ({
+      id: v.id,
+      visitorName: v.visitorName,
+      visitDate: v.startDate.toLocaleDateString(),
+      visitTime: v.time,
+    }));
 
   const getDaysForCalendar = () => {
     const daysInMonth = getDaysInMonth(month, year);
@@ -156,12 +195,22 @@ const Visits: FunctionComponent = () => {
 
   const breadcrumbs = useMemo<BreadcrumbItem[]>(() => [{ label: 'Visits' }], []);
 
-  const handleAcceptRequest = (requestId: string) => {
-    console.log('Accept request:', requestId);
+  const handleAcceptRequest = async (requestId: string) => {
+    try {
+      await api.patch(`/api/bookings/${requestId}`, { status: 'accepted' });
+      fetchVisits();
+    } catch (error) {
+      console.error('Failed to accept request:', error);
+    }
   };
 
-  const handleRejectRequest = (requestId: string) => {
-    console.log('Reject request:', requestId);
+  const handleRejectRequest = async (requestId: string) => {
+    try {
+      await api.patch(`/api/bookings/${requestId}`, { status: 'rejected' });
+      fetchVisits();
+    } catch (error) {
+      console.error('Failed to reject request:', error);
+    }
   };
 
   return (
@@ -427,7 +476,7 @@ const Visits: FunctionComponent = () => {
         {/* Visit Requests Section - Full Width Below */}
         {/* TODO: put actual requests */}
         <VisitRequestsSection
-          requests={[]}
+          requests={pendingRequests}
           onAccept={handleAcceptRequest}
           onReject={handleRejectRequest}
         />

--- a/frontend/src/pages/landlord/visits/LandlordVisits.tsx
+++ b/frontend/src/pages/landlord/visits/LandlordVisits.tsx
@@ -11,6 +11,7 @@ import LandlordDayEventsPopout, {
   type VisitSlot,
 } from '../../../components/landlord/VisitsSections/LandlordDayEventsPopout';
 import LandlordEventPopout from '../../../components/landlord/VisitsSections/LandlordEventPopout';
+import { BookingService } from '../../../service/BookingService';
 
 const Visits: FunctionComponent = () => {
   const [isSetAvailableTimeOpen, setSetAvailableTimeOpen] = useState(false);
@@ -147,8 +148,14 @@ const Visits: FunctionComponent = () => {
   const getFirstDayOfMonth = (m: number, y: number) => new Date(y, m, 1).getDay();
 
   const getVisitsForDay = (day: number) => {
-    const dayOfWeek = new Date(year, month, day).getDay();
-    return allVisits.filter((visit) => visit.dayOfWeek === dayOfWeek);
+    const targetDate = new Date(year, month, day);
+    return allVisits.filter((visit) => {
+      const vDate = new Date(visit.startDate);
+      return visit.status === 'accepted' &&
+             vDate.getDate() === targetDate.getDate() &&
+             vDate.getMonth() === targetDate.getMonth() &&
+             vDate.getFullYear() === targetDate.getFullYear();
+    });
   };
 
   // Transform visits to show all upcoming visits
@@ -197,7 +204,7 @@ const Visits: FunctionComponent = () => {
 
   const handleAcceptRequest = async (requestId: string) => {
     try {
-      await api.patch(`/api/bookings/${requestId}`, { status: 'accepted' });
+      await BookingService.updateBookingStatus(requestId as any, 'accepted');
       fetchVisits();
     } catch (error) {
       console.error('Failed to accept request:', error);
@@ -206,7 +213,7 @@ const Visits: FunctionComponent = () => {
 
   const handleRejectRequest = async (requestId: string) => {
     try {
-      await api.patch(`/api/bookings/${requestId}`, { status: 'rejected' });
+      await BookingService.updateBookingStatus(requestId as any, 'cancelled');
       fetchVisits();
     } catch (error) {
       console.error('Failed to reject request:', error);

--- a/frontend/src/pages/landlord/visits/LandlordVisits.tsx
+++ b/frontend/src/pages/landlord/visits/LandlordVisits.tsx
@@ -4,8 +4,7 @@ import { api } from '../../../service/axiosInstance';
 import { Icon } from '@iconify/react';
 import LandlordLayout, { type BreadcrumbItem } from '../../../components/landlord/LandlordLayout';
 import SetAvailableTime from '../../../components/landlord/VisitsSections/SetAvailableTime';
-import MiniCalendar from '../../../components/landlord/VisitsSections/MiniCalendar';
-import MainCalendarGrid from '../../../components/landlord/VisitsSections/MainCalendarGrid';
+import PortalPopup from '../../../components/landlord/VisitsSections/PortalPopup';
 import UpcomingVisitsSection from '../../../components/landlord/VisitsSections/UpcomingVisitsSection';
 import VisitRequestsSection from '../../../components/landlord/VisitsSections/VisitRequestsSection';
 import LandlordDayEventsPopout, {
@@ -16,11 +15,16 @@ import { BookingService } from '../../../service/BookingService';
 
 const Visits: FunctionComponent = () => {
   const [isSetAvailableTimeOpen, setSetAvailableTimeOpen] = useState(false);
+  const [isDayPopoutOpen, setDayPopoutOpen] = useState(false);
+  const [isEventPopoutOpen, setEventPopoutOpen] = useState(false);
   const [currentDate, setCurrentDate] = useState(new Date());
-  const [selectedDay, setSelectedDay] = useState<number | null>(null);
+  const [showMonthDropdown, setShowMonthDropdown] = useState(false);
+  const [showYearDropdown, setShowYearDropdown] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [selectedDayVisits, setSelectedDayVisits] = useState<VisitSlot[]>([]);
   const [selectedEvent, setSelectedEvent] = useState<VisitSlot | null>(null);
 
-  const monthNames = [
+  const MONTHS = [
     'January',
     'February',
     'March',
@@ -34,8 +38,7 @@ const Visits: FunctionComponent = () => {
     'November',
     'December',
   ];
-
-  const shortMonthNames = [
+  const MONTH_SHORT = [
     'Jan',
     'Feb',
     'Mar',
@@ -62,15 +65,9 @@ const Visits: FunctionComponent = () => {
           id: b._id,
           visitorName: b.userId?.firstName ? `${b.userId.firstName} ${b.userId.lastName}` : 'Student',
           time: new Date(b.startDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-          date: new Date(b.startDate).toLocaleDateString('en-US', {
-            month: 'long',
-            day: 'numeric',
-            year: 'numeric',
-          }),
           status: b.status,
           dayOfWeek: new Date(b.startDate).getDay(),
           startDate: new Date(b.startDate),
-          propertyName: b.facilityId?.name || 'Property',
           backgroundColor: b.status === 'accepted' ? 'bg-blue-100 dark:bg-[#12342e]' : 'bg-orange-100 dark:bg-[#342e12]',
         }));
         setAllVisits(mapped);
@@ -89,13 +86,63 @@ const Visits: FunctionComponent = () => {
   const month = currentDate.getMonth();
   const year = currentDate.getFullYear();
 
-  const handlePrevMonth = () => {
-    setCurrentDate(new Date(year, month - 1, 1));
+  const openSetAvailableTime = useCallback(() => {
+    setSetAvailableTimeOpen(true);
+  }, []);
+
+  const closeSetAvailableTime = useCallback(() => {
+    setSetAvailableTimeOpen(false);
+  }, []);
+
+  const handlePrevMonth = useCallback(() => {
+    setCurrentDate((prev) => new Date(prev.getFullYear(), prev.getMonth() - 1));
+  }, []);
+
+  const handleNextMonth = useCallback(() => {
+    setCurrentDate((prev) => new Date(prev.getFullYear(), prev.getMonth() + 1));
+  }, []);
+
+  const handleMonthSelect = (monthIdx: number) => {
+    setCurrentDate(new Date(year, monthIdx));
+    setShowMonthDropdown(false);
   };
 
-  const handleNextMonth = () => {
-    setCurrentDate(new Date(year, month + 1, 1));
+  const handleYearSelect = (selectedYear: number) => {
+    setCurrentDate(new Date(selectedYear, month));
+    setShowYearDropdown(false);
   };
+
+  const openDayPopout = useCallback((date: Date, visits: VisitSlot[]) => {
+    setSelectedDate(date);
+    setSelectedDayVisits(visits);
+    setDayPopoutOpen(true);
+  }, []);
+
+  const closeDayPopout = useCallback(() => {
+    setDayPopoutOpen(false);
+    setSelectedDate(null);
+    setSelectedDayVisits([]);
+  }, []);
+
+  const openEventPopout = useCallback((event: VisitSlot) => {
+    setSelectedEvent(event);
+    setEventPopoutOpen(true);
+  }, []);
+
+  const closeEventPopout = useCallback(() => {
+    setEventPopoutOpen(false);
+    setSelectedEvent(null);
+  }, []);
+
+  const handleUpcomingVisitClick = useCallback(
+    (visitId: string) => {
+      const visit = allVisits.find((v) => v.id === visitId);
+      if (visit) {
+        openEventPopout(visit);
+      }
+    },
+    [allVisits],
+  );
 
   const getDaysInMonth = (m: number, y: number) => new Date(y, m + 1, 0).getDate();
   const getFirstDayOfMonth = (m: number, y: number) => new Date(y, m, 1).getDay();
@@ -105,9 +152,9 @@ const Visits: FunctionComponent = () => {
     return allVisits.filter((visit) => {
       const vDate = new Date(visit.startDate);
       return visit.status === 'accepted' &&
-             vDate.getDate() === targetDate.getDate() &&
-             vDate.getMonth() === targetDate.getMonth() &&
-             vDate.getFullYear() === targetDate.getFullYear();
+        vDate.getDate() === targetDate.getDate() &&
+        vDate.getMonth() === targetDate.getMonth() &&
+        vDate.getFullYear() === targetDate.getFullYear();
     });
   };
 
@@ -133,16 +180,22 @@ const Visits: FunctionComponent = () => {
   const getDaysForCalendar = () => {
     const daysInMonth = getDaysInMonth(month, year);
     const firstDay = getFirstDayOfMonth(month, year);
-    const days = [];
+    const days: (number | null)[] = [];
 
-    // Empty slots for previous month
-    for (let i = 0; i < firstDay; i++) {
+    // Previous month's days
+    for (let i = firstDay - 1; i >= 0; i--) {
       days.push(null);
     }
 
-    // Days of current month
+    // Current month's days
     for (let i = 1; i <= daysInMonth; i++) {
       days.push(i);
+    }
+
+    // Next month's days
+    const remaining = 42 - days.length;
+    for (let i = 1; i <= remaining; i++) {
+      days.push(null);
     }
 
     return days;
@@ -169,49 +222,262 @@ const Visits: FunctionComponent = () => {
   };
 
   return (
-    <LandlordLayout breadcrumbs={breadcrumbs}>
-      <div className="flex flex-col gap-6 p-6">
-        {/* Header Section */}
-        <div className="flex justify-between items-center">
-          <div className="bg-[#c2e4dd] dark:bg-[#12342e] rounded-lg px-6 py-3">
+    <LandlordLayout activeSidebarItem="visits" breadcrumbs={breadcrumbs}>
+      <div className="flex flex-col w-full gap-4 sm:gap-6">
+        {/* Header Section - Large Title with Divider */}
+        <div className="flex flex-col gap-3 px-0">
+          <b className="relative text-xl sm:text-num-24 leading-8 text-gray dark:text-[#d7e0ef] font-inter shrink-0">
+            My Calendar
+          </b>
+          <div className="h-0.5 bg-whitesmoke-200 dark:bg-[#303331]" />
+        </div>
+
+        {/* Main Content - Two Column Layout - Responsive */}
+        <div className="flex flex-col lg:flex-row gap-4 lg:gap-6">
+          {/* LEFT SIDEBAR */}
+          <div className="w-full lg:w-72 flex flex-col gap-6 shrink-0">
+            {/* Set Available Time Slots Button */}
             <button
-              className="text-[#000] dark:text-[#72cbb8] font-semibold text-lg hover:opacity-80 transition-opacity"
-              onClick={() => setSetAvailableTimeOpen(true)}
+              type="button"
+              onClick={openSetAvailableTime}
+              className="w-full rounded-lg bg-lightcyan dark:bg-[#12342e] text-teal dark:text-[#72cbb8] font-semibold py-2 sm:py-3 px-3 sm:px-4 hover:opacity-90 transition-opacity border-none cursor-pointer font-inter text-sm sm:text-base whitespace-normal"
             >
               Set Available Time Slots
             </button>
-          </div>
-          <div className="text-2xl font-bold text-dimgray dark:text-[#d7e0ef]">
-            {monthNames[month]} {year}
-          </div>
-          <div className="flex gap-2"></div>
-        </div>
 
-        <div className="flex flex-col lg:flex-row gap-6">
-          {/* Left Column: Mini Calendar and Upcoming Visits */}
-          <div className="flex flex-col gap-6 w-full lg:w-80 shrink-0">
-            <MiniCalendar
-              currentDate={currentDate}
-              onPrevMonth={handlePrevMonth}
-              onNextMonth={handleNextMonth}
-              monthNames={shortMonthNames}
-            />
+            {/* Mini Calendar */}
+            <div className="rounded-xl bg-white dark:bg-[#141515] border border-whitesmoke-200 dark:border-[#303331] flex flex-col items-center p-4 gap-4 w-full overflow-hidden text-black dark:text-[#d7e0ef]">
+              {/* Nav */}
+              <div className="self-stretch flex items-center gap-3">
+                <button
+                  onClick={handlePrevMonth}
+                  className="rounded-full p-2 hover:bg-whitesmoke-100 dark:hover:bg-[#1f2022] transition-colors"
+                >
+                  <Icon icon="ic:round-chevron-left" className="h-5 w-5 dark:text-[#d7e0ef]" />
+                </button>
+                <div className="flex-1 flex gap-2 relative">
+                  {/* Month Dropdown */}
+                  <div className="flex-1 relative">
+                    <button
+                      onClick={() => setShowMonthDropdown(!showMonthDropdown)}
+                      className="w-full rounded-md border border-gainsboro dark:border-[#303331] flex items-center p-2 gap-1 text-xs hover:bg-gray-50 dark:hover:bg-[#1f2022] dark:bg-[#1f2022]"
+                    >
+                      <span className="flex-1">{MONTHS[month].substring(0, 3)}</span>
+                      <Icon
+                        icon="ic:round-keyboard-arrow-down"
+                        className={`h-4 w-4 transition-transform ${showMonthDropdown ? 'rotate-180' : ''
+                          }`}
+                      />
+                    </button>
+                    {showMonthDropdown && (
+                      <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-[#141515] border border-gainsboro dark:border-[#303331] rounded-md z-10 shadow-lg max-h-48 overflow-y-auto">
+                        {MONTHS.map((m, idx) => (
+                          <button
+                            key={m}
+                            onClick={() => handleMonthSelect(idx)}
+                            className={`w-full text-left px-3 py-2 text-xs hover:bg-blue-50 dark:hover:bg-[#1f3a34] ${idx === month ? 'bg-lightcyan-100 dark:bg-[#12342e] font-bold text-teal dark:text-[#72cbb8]' : ''
+                              }`}
+                          >
+                            {m}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
 
-            <UpcomingVisitsSection visits={upcomingVisits} />
+                  {/* Year Dropdown */}
+                  <div className="flex-1 relative">
+                    <button
+                      onClick={() => setShowYearDropdown(!showYearDropdown)}
+                      className="w-full rounded-md border border-gainsboro dark:border-[#303331] flex items-center p-2 gap-1 text-xs hover:bg-gray-50 dark:hover:bg-[#1f2022] dark:bg-[#1f2022]"
+                    >
+                      <span className="flex-1">{year}</span>
+                      <Icon
+                        icon="ic:round-keyboard-arrow-down"
+                        className={`h-4 w-4 transition-transform ${showYearDropdown ? 'rotate-180' : ''
+                          }`}
+                      />
+                    </button>
+                    {showYearDropdown && (
+                      <div className="absolute top-full right-0 left-0 mt-1 bg-white dark:bg-[#141515] border border-gainsboro dark:border-[#303331] rounded-md z-10 shadow-lg max-h-48 overflow-y-auto">
+                        {Array.from({ length: 21 }, (_, i) => year - 10 + i).map((y) => (
+                          <button
+                            key={y}
+                            onClick={() => handleYearSelect(y)}
+                            className={`w-full text-left px-3 py-2 text-xs hover:bg-blue-50 dark:hover:bg-[#1f3a34] ${y === year ? 'bg-lightcyan-100 dark:bg-[#12342e] font-bold text-teal dark:text-[#72cbb8]' : ''
+                              }`}
+                          >
+                            {y}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <button
+                  onClick={handleNextMonth}
+                  className="rounded-full p-2 hover:bg-whitesmoke-100 dark:hover:bg-[#1f2022] transition-colors"
+                >
+                  <Icon icon="ic:round-chevron-right" className="h-5 w-5 dark:text-[#d7e0ef]" />
+                </button>
+              </div>
+
+              {/* Day labels */}
+              <div className="self-stretch flex flex-col gap-0.5 text-center">
+                <div className="grid grid-cols-7 text-xs text-gray dark:text-[#a4acba] font-inter">
+                  {['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'].map((d) => (
+                    <div key={d} className="flex items-center justify-center py-1">
+                      {d}
+                    </div>
+                  ))}
+                </div>
+
+                {/* Date grid */}
+                <div className="flex flex-col gap-0.5 text-xs text-black dark:text-[#d7e0ef]">
+                  {(() => {
+                    const daysInMonth = getDaysInMonth(month, year);
+                    const firstDay = getFirstDayOfMonth(month, year);
+                    const weeks: (number | null)[][] = [];
+                    let week: (number | null)[] = new Array(firstDay).fill(null);
+                    for (let day = 1; day <= daysInMonth; day++) {
+                      week.push(day);
+                      if (week.length === 7) {
+                        weeks.push(week);
+                        week = [];
+                      }
+                    }
+                    if (week.length > 0) {
+                      while (week.length < 7) {
+                        week.push(null);
+                      }
+                      weeks.push(week);
+                    }
+                    const today = new Date();
+                    const isCurrentMonth =
+                      today.getFullYear() === year && today.getMonth() === month;
+                    return weeks.map((weekDays, wi) => (
+                      <div key={wi} className="grid grid-cols-7 gap-0.5">
+                        {weekDays.map((day, di) => {
+                          const isTodayDay =
+                            isCurrentMonth && day === today.getDate() && day !== null;
+                          return (
+                            <button
+                              key={di}
+                              onClick={() => {
+                                if (day !== null) {
+                                  const clickedDate = new Date(year, month, day);
+                                  const dayVisits = getVisitsForDay(day);
+                                  openDayPopout(clickedDate, dayVisits);
+                                }
+                              }}
+                              disabled={day === null}
+                              className={[
+                                'rounded-md flex items-center justify-center p-2 aspect-square transition-colors',
+                                day === null
+                                  ? 'cursor-default opacity-0'
+                                  : 'cursor-pointer hover:bg-gray-100 dark:hover:bg-[#1f2022]',
+                                isTodayDay
+                                  ? 'bg-teal text-white font-bold hover:bg-teal/80 dark:bg-[#72cbb8] dark:text-[#141515] dark:hover:bg-[#5db8a5]'
+                                  : '',
+                              ].join(' ')}
+                            >
+                              {day ?? ''}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ));
+                  })()}
+                </div>
+              </div>
+            </div>
+
+            {/* Upcoming Visits Section */}
+            <div className="bg-white dark:bg-[#141515] rounded-num-8 p-3 sm:p-4 border border-whitesmoke-200 dark:border-[#303331] w-full">
+              <UpcomingVisitsSection
+                visits={upcomingVisits}
+                onVisitClick={handleUpcomingVisitClick}
+              />
+            </div>
           </div>
 
-          {/* Right Column: Main Calendar Grid */}
-          <div className="flex-1 min-w-0">
-            <MainCalendarGrid
-              days={getDaysForCalendar()}
-              getVisitsForDay={getVisitsForDay}
-              onDayClick={(day) => setSelectedDay(day)}
-              onEventClick={(event) => setSelectedEvent(event)}
-            />
+          {/* RIGHT MAIN CONTENT */}
+          <div className="flex-1 flex flex-col gap-4 sm:gap-6 min-w-0">
+            {/* Calendar Header - Month and Year only */}
+            <div className="flex items-center justify-center px-2">
+              <h2 className="text-xl sm:text-2xl font-bold text-black dark:text-[#d7e0ef] font-inter">
+                {MONTHS[month]} {year}
+              </h2>
+            </div>
+
+            {/* Calendar Grid */}
+            <div className="bg-white dark:bg-[#141515] rounded-num-8 p-3 sm:p-6 border border-whitesmoke-200 dark:border-[#303331] flex-1 min-w-0 overflow-auto">
+              {/* Day Headers */}
+              <div className="grid grid-cols-7 gap-1 sm:gap-2 mb-2 sm:mb-4 text-center text-xs sm:text-num-14 font-semibold text-dimgray dark:text-[#a4acba] font-inter">
+                <div>Sun</div>
+                <div>Mon</div>
+                <div>Tue</div>
+                <div>Wed</div>
+                <div>Thu</div>
+                <div>Fri</div>
+                <div>Sat</div>
+              </div>
+
+              {/* Calendar Days Grid - 6 weeks */}
+              <div className="grid grid-cols-7 gap-1 sm:gap-2">
+                {getDaysForCalendar().map((day, idx) => {
+                  const dayVisits = day ? getVisitsForDay(day) : [];
+                  const hasEvents = day && dayVisits.length > 0;
+                  return (
+                    <div
+                      key={idx}
+                      className={`min-h-20 sm:min-h-28 p-1 sm:p-3 rounded border transition-colors text-xs sm:text-base ${day === null
+                          ? 'bg-whitesmoke-100 border-whitesmoke-200 dark:bg-[#1f2022] dark:border-[#303331] cursor-default'
+                          : day === new Date().getDate() &&
+                            month === new Date().getMonth() &&
+                            year === new Date().getFullYear()
+                            ? 'bg-teal-50 border-teal dark:bg-[#12342e] dark:border-[#72cbb8]'
+                            : 'bg-white border-whitesmoke-200 cursor-default dark:bg-[#141515] dark:border-[#303331]'
+                        }`}
+                    >
+                      {day && (
+                        <>
+                          <div className={`text-xs sm:text-num-14 font-semibold font-inter mb-1 ${day === new Date().getDate() && month === new Date().getMonth() && year === new Date().getFullYear() ? 'text-teal dark:text-[#72cbb8]' : 'text-dimgray dark:text-[#d7e0ef]'}`}>
+                            {day}
+                          </div>
+                          <div className="flex flex-col gap-0.5 sm:gap-1 text-xs">
+                            {dayVisits.slice(0, 1).map((visit) => (
+                              <button
+                                key={visit.id}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  openEventPopout(visit);
+                                }}
+                                className={`w-full text-left p-0.5 sm:p-1 rounded ${visit.backgroundColor} cursor-pointer hover:opacity-80 transition-opacity overflow-hidden`}
+                              >
+                                <div className="truncate font-semibold text-xs">
+                                  {visit.visitorName}
+                                </div>
+                              </button>
+                            ))}
+                            {dayVisits.length > 1 && (
+                              <div className="text-xs text-teal font-semibold">
+                                +{dayVisits.length - 1}
+                              </div>
+                            )}
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
           </div>
         </div>
 
         {/* Visit Requests Section - Full Width Below */}
+        {/* TODO: put actual requests */}
         <VisitRequestsSection
           requests={pendingRequests}
           onAccept={handleAcceptRequest}
@@ -219,27 +485,38 @@ const Visits: FunctionComponent = () => {
         />
       </div>
 
-      {/* Modals and Popouts */}
       {isSetAvailableTimeOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-          <SetAvailableTime onClose={() => setSetAvailableTimeOpen(false)} />
-        </div>
+        <PortalPopup
+          overlayColor="rgba(113, 113, 113, 0.3)"
+          placement="Centered"
+          onOutsideClick={closeSetAvailableTime}
+        >
+          <SetAvailableTime onClose={closeSetAvailableTime} />
+        </PortalPopup>
       )}
 
-      {selectedDay !== null && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      {isDayPopoutOpen && selectedDate && (
+        <PortalPopup
+          overlayColor="rgba(113, 113, 113, 0.3)"
+          placement="Centered"
+          onOutsideClick={closeDayPopout}
+        >
           <LandlordDayEventsPopout
-            date={new Date(year, month, selectedDay)}
-            events={getVisitsForDay(selectedDay)}
-            onClose={() => setSelectedDay(null)}
+            date={selectedDate}
+            events={selectedDayVisits}
+            onClose={closeDayPopout}
           />
-        </div>
+        </PortalPopup>
       )}
 
-      {selectedEvent !== null && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-          <LandlordEventPopout event={selectedEvent} onClose={() => setSelectedEvent(null)} />
-        </div>
+      {isEventPopoutOpen && selectedEvent && (
+        <PortalPopup
+          overlayColor="rgba(113, 113, 113, 0.3)"
+          placement="Centered"
+          onOutsideClick={closeEventPopout}
+        >
+          <LandlordEventPopout event={selectedEvent} onClose={closeEventPopout} />
+        </PortalPopup>
       )}
     </LandlordLayout>
   );

--- a/frontend/src/pages/landlord/visits/LandlordVisits.tsx
+++ b/frontend/src/pages/landlord/visits/LandlordVisits.tsx
@@ -172,8 +172,9 @@ const Visits: FunctionComponent = () => {
     .map((v) => ({
       id: v.id,
       visitorName: v.visitorName,
-      visitDate: v.startDate.toLocaleDateString(),
-      visitTime: v.time,
+      dateTime: `${v.startDate.toLocaleDateString()} - ${v.time}`,
+      propertyName: v.propertyName,
+      buildingName: 'Building',
     }));
 
   const getDaysForCalendar = () => {

--- a/frontend/src/pages/landlord/visits/LandlordVisits.tsx
+++ b/frontend/src/pages/landlord/visits/LandlordVisits.tsx
@@ -4,7 +4,8 @@ import { api } from '../../../service/axiosInstance';
 import { Icon } from '@iconify/react';
 import LandlordLayout, { type BreadcrumbItem } from '../../../components/landlord/LandlordLayout';
 import SetAvailableTime from '../../../components/landlord/VisitsSections/SetAvailableTime';
-import PortalPopup from '../../../components/landlord/VisitsSections/PortalPopup';
+import MiniCalendar from '../../../components/landlord/VisitsSections/MiniCalendar';
+import MainCalendarGrid from '../../../components/landlord/VisitsSections/MainCalendarGrid';
 import UpcomingVisitsSection from '../../../components/landlord/VisitsSections/UpcomingVisitsSection';
 import VisitRequestsSection from '../../../components/landlord/VisitsSections/VisitRequestsSection';
 import LandlordDayEventsPopout, {
@@ -15,16 +16,11 @@ import { BookingService } from '../../../service/BookingService';
 
 const Visits: FunctionComponent = () => {
   const [isSetAvailableTimeOpen, setSetAvailableTimeOpen] = useState(false);
-  const [isDayPopoutOpen, setDayPopoutOpen] = useState(false);
-  const [isEventPopoutOpen, setEventPopoutOpen] = useState(false);
   const [currentDate, setCurrentDate] = useState(new Date());
-  const [showMonthDropdown, setShowMonthDropdown] = useState(false);
-  const [showYearDropdown, setShowYearDropdown] = useState(false);
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const [selectedDayVisits, setSelectedDayVisits] = useState<VisitSlot[]>([]);
+  const [selectedDay, setSelectedDay] = useState<number | null>(null);
   const [selectedEvent, setSelectedEvent] = useState<VisitSlot | null>(null);
 
-  const MONTHS = [
+  const monthNames = [
     'January',
     'February',
     'March',
@@ -38,7 +34,8 @@ const Visits: FunctionComponent = () => {
     'November',
     'December',
   ];
-  const MONTH_SHORT = [
+
+  const shortMonthNames = [
     'Jan',
     'Feb',
     'Mar',
@@ -65,9 +62,15 @@ const Visits: FunctionComponent = () => {
           id: b._id,
           visitorName: b.userId?.firstName ? `${b.userId.firstName} ${b.userId.lastName}` : 'Student',
           time: new Date(b.startDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+          date: new Date(b.startDate).toLocaleDateString('en-US', {
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric',
+          }),
           status: b.status,
           dayOfWeek: new Date(b.startDate).getDay(),
           startDate: new Date(b.startDate),
+          propertyName: b.facilityId?.name || 'Property',
           backgroundColor: b.status === 'accepted' ? 'bg-blue-100 dark:bg-[#12342e]' : 'bg-orange-100 dark:bg-[#342e12]',
         }));
         setAllVisits(mapped);
@@ -86,63 +89,13 @@ const Visits: FunctionComponent = () => {
   const month = currentDate.getMonth();
   const year = currentDate.getFullYear();
 
-  const openSetAvailableTime = useCallback(() => {
-    setSetAvailableTimeOpen(true);
-  }, []);
-
-  const closeSetAvailableTime = useCallback(() => {
-    setSetAvailableTimeOpen(false);
-  }, []);
-
-  const handlePrevMonth = useCallback(() => {
-    setCurrentDate((prev) => new Date(prev.getFullYear(), prev.getMonth() - 1));
-  }, []);
-
-  const handleNextMonth = useCallback(() => {
-    setCurrentDate((prev) => new Date(prev.getFullYear(), prev.getMonth() + 1));
-  }, []);
-
-  const handleMonthSelect = (monthIdx: number) => {
-    setCurrentDate(new Date(year, monthIdx));
-    setShowMonthDropdown(false);
+  const handlePrevMonth = () => {
+    setCurrentDate(new Date(year, month - 1, 1));
   };
 
-  const handleYearSelect = (selectedYear: number) => {
-    setCurrentDate(new Date(selectedYear, month));
-    setShowYearDropdown(false);
+  const handleNextMonth = () => {
+    setCurrentDate(new Date(year, month + 1, 1));
   };
-
-  const openDayPopout = useCallback((date: Date, visits: VisitSlot[]) => {
-    setSelectedDate(date);
-    setSelectedDayVisits(visits);
-    setDayPopoutOpen(true);
-  }, []);
-
-  const closeDayPopout = useCallback(() => {
-    setDayPopoutOpen(false);
-    setSelectedDate(null);
-    setSelectedDayVisits([]);
-  }, []);
-
-  const openEventPopout = useCallback((event: VisitSlot) => {
-    setSelectedEvent(event);
-    setEventPopoutOpen(true);
-  }, []);
-
-  const closeEventPopout = useCallback(() => {
-    setEventPopoutOpen(false);
-    setSelectedEvent(null);
-  }, []);
-
-  const handleUpcomingVisitClick = useCallback(
-    (visitId: string) => {
-      const visit = allVisits.find((v) => v.id === visitId);
-      if (visit) {
-        openEventPopout(visit);
-      }
-    },
-    [allVisits],
-  );
 
   const getDaysInMonth = (m: number, y: number) => new Date(y, m + 1, 0).getDate();
   const getFirstDayOfMonth = (m: number, y: number) => new Date(y, m, 1).getDay();
@@ -180,22 +133,16 @@ const Visits: FunctionComponent = () => {
   const getDaysForCalendar = () => {
     const daysInMonth = getDaysInMonth(month, year);
     const firstDay = getFirstDayOfMonth(month, year);
-    const days: (number | null)[] = [];
+    const days = [];
 
-    // Previous month's days
-    for (let i = firstDay - 1; i >= 0; i--) {
+    // Empty slots for previous month
+    for (let i = 0; i < firstDay; i++) {
       days.push(null);
     }
 
-    // Current month's days
+    // Days of current month
     for (let i = 1; i <= daysInMonth; i++) {
       days.push(i);
-    }
-
-    // Next month's days
-    const remaining = 42 - days.length;
-    for (let i = 1; i <= remaining; i++) {
-      days.push(null);
     }
 
     return days;
@@ -222,267 +169,49 @@ const Visits: FunctionComponent = () => {
   };
 
   return (
-    <LandlordLayout activeSidebarItem="visits" breadcrumbs={breadcrumbs}>
-      <div className="flex flex-col w-full gap-4 sm:gap-6">
-        {/* Header Section - Large Title with Divider */}
-        <div className="flex flex-col gap-3 px-0">
-          <b className="relative text-xl sm:text-num-24 leading-8 text-gray dark:text-[#d7e0ef] font-inter shrink-0">
-            My Calendar
-          </b>
-          <div className="h-0.5 bg-whitesmoke-200 dark:bg-[#303331]" />
-        </div>
-
-        {/* Main Content - Two Column Layout - Responsive */}
-        <div className="flex flex-col lg:flex-row gap-4 lg:gap-6">
-          {/* LEFT SIDEBAR */}
-          <div className="w-full lg:w-72 flex flex-col gap-6 shrink-0">
-            {/* Set Available Time Slots Button */}
+    <LandlordLayout breadcrumbs={breadcrumbs}>
+      <div className="flex flex-col gap-6 p-6">
+        {/* Header Section */}
+        <div className="flex justify-between items-center">
+          <div className="bg-[#c2e4dd] dark:bg-[#12342e] rounded-lg px-6 py-3">
             <button
-              type="button"
-              onClick={openSetAvailableTime}
-              className="w-full rounded-lg bg-lightcyan dark:bg-[#12342e] text-teal dark:text-[#72cbb8] font-semibold py-2 sm:py-3 px-3 sm:px-4 hover:opacity-90 transition-opacity border-none cursor-pointer font-inter text-sm sm:text-base whitespace-normal"
+              className="text-[#000] dark:text-[#72cbb8] font-semibold text-lg hover:opacity-80 transition-opacity"
+              onClick={() => setSetAvailableTimeOpen(true)}
             >
               Set Available Time Slots
             </button>
+          </div>
+          <div className="text-2xl font-bold text-dimgray dark:text-[#d7e0ef]">
+            {monthNames[month]} {year}
+          </div>
+          <div className="flex gap-2"></div>
+        </div>
 
-            {/* Mini Calendar */}
-            <div className="rounded-xl bg-white dark:bg-[#141515] border border-whitesmoke-200 dark:border-[#303331] flex flex-col items-center p-4 gap-4 w-full overflow-hidden text-black dark:text-[#d7e0ef]">
-              {/* Nav */}
-              <div className="self-stretch flex items-center gap-3">
-                <button
-                  onClick={handlePrevMonth}
-                  className="rounded-full p-2 hover:bg-whitesmoke-100 dark:hover:bg-[#1f2022] transition-colors"
-                >
-                  <Icon icon="ic:round-chevron-left" className="h-5 w-5 dark:text-[#d7e0ef]" />
-                </button>
-                <div className="flex-1 flex gap-2 relative">
-                  {/* Month Dropdown */}
-                  <div className="flex-1 relative">
-                    <button
-                      onClick={() => setShowMonthDropdown(!showMonthDropdown)}
-                      className="w-full rounded-md border border-gainsboro dark:border-[#303331] flex items-center p-2 gap-1 text-xs hover:bg-gray-50 dark:hover:bg-[#1f2022] dark:bg-[#1f2022]"
-                    >
-                      <span className="flex-1">{MONTHS[month].substring(0, 3)}</span>
-                      <Icon
-                        icon="ic:round-keyboard-arrow-down"
-                        className={`h-4 w-4 transition-transform ${
-                          showMonthDropdown ? 'rotate-180' : ''
-                        }`}
-                      />
-                    </button>
-                    {showMonthDropdown && (
-                      <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-[#141515] border border-gainsboro dark:border-[#303331] rounded-md z-10 shadow-lg max-h-48 overflow-y-auto">
-                        {MONTHS.map((m, idx) => (
-                          <button
-                            key={m}
-                            onClick={() => handleMonthSelect(idx)}
-                            className={`w-full text-left px-3 py-2 text-xs hover:bg-blue-50 dark:hover:bg-[#1f3a34] ${
-                              idx === month ? 'bg-lightcyan-100 dark:bg-[#12342e] font-bold text-teal dark:text-[#72cbb8]' : ''
-                            }`}
-                          >
-                            {m}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
+        <div className="flex flex-col lg:flex-row gap-6">
+          {/* Left Column: Mini Calendar and Upcoming Visits */}
+          <div className="flex flex-col gap-6 w-full lg:w-80 shrink-0">
+            <MiniCalendar
+              currentDate={currentDate}
+              onPrevMonth={handlePrevMonth}
+              onNextMonth={handleNextMonth}
+              monthNames={shortMonthNames}
+            />
 
-                  {/* Year Dropdown */}
-                  <div className="flex-1 relative">
-                    <button
-                      onClick={() => setShowYearDropdown(!showYearDropdown)}
-                      className="w-full rounded-md border border-gainsboro dark:border-[#303331] flex items-center p-2 gap-1 text-xs hover:bg-gray-50 dark:hover:bg-[#1f2022] dark:bg-[#1f2022]"
-                    >
-                      <span className="flex-1">{year}</span>
-                      <Icon
-                        icon="ic:round-keyboard-arrow-down"
-                        className={`h-4 w-4 transition-transform ${
-                          showYearDropdown ? 'rotate-180' : ''
-                        }`}
-                      />
-                    </button>
-                    {showYearDropdown && (
-                      <div className="absolute top-full right-0 left-0 mt-1 bg-white dark:bg-[#141515] border border-gainsboro dark:border-[#303331] rounded-md z-10 shadow-lg max-h-48 overflow-y-auto">
-                        {Array.from({ length: 21 }, (_, i) => year - 10 + i).map((y) => (
-                          <button
-                            key={y}
-                            onClick={() => handleYearSelect(y)}
-                            className={`w-full text-left px-3 py-2 text-xs hover:bg-blue-50 dark:hover:bg-[#1f3a34] ${
-                              y === year ? 'bg-lightcyan-100 dark:bg-[#12342e] font-bold text-teal dark:text-[#72cbb8]' : ''
-                            }`}
-                          >
-                            {y}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
-                <button
-                  onClick={handleNextMonth}
-                  className="rounded-full p-2 hover:bg-whitesmoke-100 dark:hover:bg-[#1f2022] transition-colors"
-                >
-                  <Icon icon="ic:round-chevron-right" className="h-5 w-5 dark:text-[#d7e0ef]" />
-                </button>
-              </div>
-
-              {/* Day labels */}
-              <div className="self-stretch flex flex-col gap-0.5 text-center">
-                <div className="grid grid-cols-7 text-xs text-gray dark:text-[#a4acba] font-inter">
-                  {['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'].map((d) => (
-                    <div key={d} className="flex items-center justify-center py-1">
-                      {d}
-                    </div>
-                  ))}
-                </div>
-
-                {/* Date grid */}
-                <div className="flex flex-col gap-0.5 text-xs text-black dark:text-[#d7e0ef]">
-                  {(() => {
-                    const daysInMonth = getDaysInMonth(month, year);
-                    const firstDay = getFirstDayOfMonth(month, year);
-                    const weeks: (number | null)[][] = [];
-                    let week: (number | null)[] = new Array(firstDay).fill(null);
-                    for (let day = 1; day <= daysInMonth; day++) {
-                      week.push(day);
-                      if (week.length === 7) {
-                        weeks.push(week);
-                        week = [];
-                      }
-                    }
-                    if (week.length > 0) {
-                      while (week.length < 7) {
-                        week.push(null);
-                      }
-                      weeks.push(week);
-                    }
-                    const today = new Date();
-                    const isCurrentMonth =
-                      today.getFullYear() === year && today.getMonth() === month;
-                    return weeks.map((weekDays, wi) => (
-                      <div key={wi} className="grid grid-cols-7 gap-0.5">
-                        {weekDays.map((day, di) => {
-                          const isTodayDay =
-                            isCurrentMonth && day === today.getDate() && day !== null;
-                          return (
-                            <button
-                              key={di}
-                              onClick={() => {
-                                if (day !== null) {
-                                  const clickedDate = new Date(year, month, day);
-                                  const dayVisits = getVisitsForDay(day);
-                                  openDayPopout(clickedDate, dayVisits);
-                                }
-                              }}
-                              disabled={day === null}
-                              className={[
-                                'rounded-md flex items-center justify-center p-2 aspect-square transition-colors',
-                                day === null
-                                  ? 'cursor-default opacity-0'
-                                  : 'cursor-pointer hover:bg-gray-100 dark:hover:bg-[#1f2022]',
-                                isTodayDay
-                                  ? 'bg-teal text-white font-bold hover:bg-teal/80 dark:bg-[#72cbb8] dark:text-[#141515] dark:hover:bg-[#5db8a5]'
-                                  : '',
-                              ].join(' ')}
-                            >
-                              {day ?? ''}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    ));
-                  })()}
-                </div>
-              </div>
-            </div>
-
-            {/* Upcoming Visits Section */}
-            <div className="bg-white dark:bg-[#141515] rounded-num-8 p-3 sm:p-4 border border-whitesmoke-200 dark:border-[#303331] w-full">
-              <UpcomingVisitsSection
-                visits={upcomingVisits}
-                onVisitClick={handleUpcomingVisitClick}
-              />
-            </div>
+            <UpcomingVisitsSection visits={upcomingVisits} />
           </div>
 
-          {/* RIGHT MAIN CONTENT */}
-          <div className="flex-1 flex flex-col gap-4 sm:gap-6 min-w-0">
-            {/* Calendar Header - Month and Year only */}
-            <div className="flex items-center justify-center px-2">
-              <h2 className="text-xl sm:text-2xl font-bold text-black dark:text-[#d7e0ef] font-inter">
-                {MONTHS[month]} {year}
-              </h2>
-            </div>
-
-            {/* Calendar Grid */}
-            <div className="bg-white dark:bg-[#141515] rounded-num-8 p-3 sm:p-6 border border-whitesmoke-200 dark:border-[#303331] flex-1 min-w-0 overflow-auto">
-              {/* Day Headers */}
-              <div className="grid grid-cols-7 gap-1 sm:gap-2 mb-2 sm:mb-4 text-center text-xs sm:text-num-14 font-semibold text-dimgray dark:text-[#a4acba] font-inter">
-                <div>Sun</div>
-                <div>Mon</div>
-                <div>Tue</div>
-                <div>Wed</div>
-                <div>Thu</div>
-                <div>Fri</div>
-                <div>Sat</div>
-              </div>
-
-              {/* Calendar Days Grid - 6 weeks */}
-              <div className="grid grid-cols-7 gap-1 sm:gap-2">
-                {getDaysForCalendar().map((day, idx) => {
-                  const dayVisits = day ? getVisitsForDay(day) : [];
-                  const hasEvents = day && dayVisits.length > 0;
-                  return (
-                    <div
-                      key={idx}
-                      className={`min-h-20 sm:min-h-28 p-1 sm:p-3 rounded border transition-colors text-xs sm:text-base ${
-                        day === null
-                          ? 'bg-whitesmoke-100 border-whitesmoke-200 dark:bg-[#1f2022] dark:border-[#303331] cursor-default'
-                          : day === new Date().getDate() &&
-                              month === new Date().getMonth() &&
-                              year === new Date().getFullYear()
-                            ? 'bg-teal-50 border-teal dark:bg-[#12342e] dark:border-[#72cbb8]'
-                            : 'bg-white border-whitesmoke-200 cursor-default dark:bg-[#141515] dark:border-[#303331]'
-                      }`}
-                    >
-                      {day && (
-                        <>
-                          <div className={`text-xs sm:text-num-14 font-semibold font-inter mb-1 ${day === new Date().getDate() && month === new Date().getMonth() && year === new Date().getFullYear() ? 'text-teal dark:text-[#72cbb8]' : 'text-dimgray dark:text-[#d7e0ef]'}`}>
-                            {day}
-                          </div>
-                          <div className="flex flex-col gap-0.5 sm:gap-1 text-xs">
-                            {dayVisits.slice(0, 1).map((visit) => (
-                              <button
-                                key={visit.id}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  openEventPopout(visit);
-                                }}
-                                className={`w-full text-left p-0.5 sm:p-1 rounded ${visit.backgroundColor} cursor-pointer hover:opacity-80 transition-opacity overflow-hidden`}
-                              >
-                                <div className="truncate font-semibold text-xs">
-                                  {visit.visitorName}
-                                </div>
-                              </button>
-                            ))}
-                            {dayVisits.length > 1 && (
-                              <div className="text-xs text-teal font-semibold">
-                                +{dayVisits.length - 1}
-                              </div>
-                            )}
-                          </div>
-                        </>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
+          {/* Right Column: Main Calendar Grid */}
+          <div className="flex-1 min-w-0">
+            <MainCalendarGrid
+              days={getDaysForCalendar()}
+              getVisitsForDay={getVisitsForDay}
+              onDayClick={(day) => setSelectedDay(day)}
+              onEventClick={(event) => setSelectedEvent(event)}
+            />
           </div>
         </div>
 
         {/* Visit Requests Section - Full Width Below */}
-        {/* TODO: put actual requests */}
         <VisitRequestsSection
           requests={pendingRequests}
           onAccept={handleAcceptRequest}
@@ -490,38 +219,27 @@ const Visits: FunctionComponent = () => {
         />
       </div>
 
+      {/* Modals and Popouts */}
       {isSetAvailableTimeOpen && (
-        <PortalPopup
-          overlayColor="rgba(113, 113, 113, 0.3)"
-          placement="Centered"
-          onOutsideClick={closeSetAvailableTime}
-        >
-          <SetAvailableTime onClose={closeSetAvailableTime} />
-        </PortalPopup>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <SetAvailableTime onClose={() => setSetAvailableTimeOpen(false)} />
+        </div>
       )}
 
-      {isDayPopoutOpen && selectedDate && (
-        <PortalPopup
-          overlayColor="rgba(113, 113, 113, 0.3)"
-          placement="Centered"
-          onOutsideClick={closeDayPopout}
-        >
+      {selectedDay !== null && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
           <LandlordDayEventsPopout
-            date={selectedDate}
-            events={selectedDayVisits}
-            onClose={closeDayPopout}
+            date={new Date(year, month, selectedDay)}
+            events={getVisitsForDay(selectedDay)}
+            onClose={() => setSelectedDay(null)}
           />
-        </PortalPopup>
+        </div>
       )}
 
-      {isEventPopoutOpen && selectedEvent && (
-        <PortalPopup
-          overlayColor="rgba(113, 113, 113, 0.3)"
-          placement="Centered"
-          onOutsideClick={closeEventPopout}
-        >
-          <LandlordEventPopout event={selectedEvent} onClose={closeEventPopout} />
-        </PortalPopup>
+      {selectedEvent !== null && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <LandlordEventPopout event={selectedEvent} onClose={() => setSelectedEvent(null)} />
+        </div>
       )}
     </LandlordLayout>
   );

--- a/frontend/src/service/BookingService.ts
+++ b/frontend/src/service/BookingService.ts
@@ -46,9 +46,9 @@ export const BookingService = {
     }
   },
 
-  async updateBookingStatus(bookingId: string) {
+  async updateBookingStatus(bookingId: string, status: 'accepted' | 'cancelled') {
     try {
-      const response = await api.patch(`/api/bookings/${bookingId}`, {});
+      const response = await api.patch(`/api/bookings/${bookingId}`, { status });
 
       return response.data;
     } catch (error) {

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -2,7 +2,7 @@ export const ROOM_TYPES = ['single', 'double', 'shared'] as const;
 export const FACILITY_TYPES = ['on-campus', 'off-campus', 'partner housing'] as const;
 export const USER_TYPES = ['Admin', 'Landlord', 'Manager', 'Student'] as const;
 export const DOCUMENT_STATUS = ['accepted', 'rejected', 'pending'] as const;
-export const BOOKING_STATUS = ['finished', 'pending', 'cancelled'] as const;
+export const BOOKING_STATUS = ['finished', 'pending', 'cancelled', 'accepted', 'rejected'] as const;
 export const APPLICATION_STATUS = [
   'pending',
   'rejected',


### PR DESCRIPTION
to test:
- open two accounts, one for landlord and one user
- make sure landlord has a unit for the user to see
- go to visits -> see available time slots -> choose your available timeslots then save
- using user account, go to the unit owned by your landlord account, and book a visit
- available time will be your available time selected previously, choose one
- after selecting book, go to your landlord account visits tab, you should see a visit request (refresh if not)
- after approving, it should be visible on the calendar of both the landlord and the user